### PR TITLE
Switch SD to OTLP part 2: histograms

### DIFF
--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -16,6 +16,8 @@ package retrieval
 import (
 	"context"
 	"math"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,13 +26,19 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/tsdb"
+	tsdbLabels "github.com/prometheus/tsdb/labels"
 
 	common_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
 	metric_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
 	resource_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/resource/v1"
 )
 
-const otlpCUMULATIVE = metric_pb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+const (
+	otlpCUMULATIVE = metric_pb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+
+	promInstLibrary = "github.com/lightstep/lightstep-prometheus-sidecar"
+	promInstVersion = "0.1"
+)
 
 // Appender appends a time series with exactly one data point. A hash for the series
 // (but not the data point) must be provided.
@@ -76,6 +84,7 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*me
 	// functionality, where the OTLP exporter already applies
 	// this.
 	ts, point := protoTimeseries(entry.desc)
+	labels := protoStringLabels(entry.desc.Labels)
 
 	var resetTimestamp int64
 
@@ -89,7 +98,6 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*me
 		}
 		startNanos := getNanos(resetTimestamp)
 		sampleNanos := getNanos(sample.T)
-		labels := protoStringLabels(entry.desc.Labels)
 
 		if entry.metadata.ValueType == metadata.INT64 {
 			integer := &metric_pb.IntDataPoint{
@@ -126,7 +134,6 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*me
 
 	case textparse.MetricTypeGauge, textparse.MetricTypeUnknown:
 		sampleNanos := getNanos(sample.T)
-		labels := protoStringLabels(entry.desc.Labels)
 
 		if entry.metadata.ValueType == metadata.INT64 {
 			integer := &metric_pb.IntDataPoint{
@@ -154,7 +161,7 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*me
 			}
 		}
 
-	case textparse.MetricTypeSummary, textparse.MetricTypeHistogram:
+	case textparse.MetricTypeSummary:
 		return nil, 0, tailSamples, errors.Errorf("unimplemented metric type %q", entry.metadata.MetricType)
 
 	// case textparse.MetricTypeSummary:
@@ -181,17 +188,30 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*me
 	// 		return nil, 0, tailSamples, errors.Errorf("unexpected metric name suffix %q", entry.suffix)
 	// 	}
 
-	// case textparse.MetricTypeHistogram:
-	// 	// We pass in the original lset for matching since Prometheus's target label must
-	// 	// be the same as well.
-	// 	value, resetTimestamp, tailSamples, err = b.buildDistribution(ctx, entry.metadata.Metric, entry.lset, samples)
-	// 	if value == nil || err != nil {
-	// 		return nil, 0, tailSamples, err
-	// 	}
-	// 	point.Interval.StartTime = getTimestamp(resetTimestamp)
-	// 	point.Value = &monitoring_pb.TypedValue{
-	// 		Value: &monitoring_pb.TypedValue_DistributionValue{v},
-	// 	}
+	case textparse.MetricTypeHistogram:
+		// We pass in the original lset for matching since Prometheus's target label must
+		// be the same as well.
+		// Note: Always using DoubleHistogram points, ignores entry.metadata.ValueType.
+		var value *metric_pb.DoubleHistogramDataPoint
+		value, resetTimestamp, tailSamples, err = b.buildHistogram(ctx, entry.metadata.Metric, entry.lset, samples)
+		if value == nil || err != nil {
+			return nil, 0, tailSamples, err
+		}
+
+		value.Labels = labels
+		value.StartTimeUnixNano = getNanos(resetTimestamp)
+		value.TimeUnixNano = getNanos(sample.T)
+
+		doubleHist := &metric_pb.DoubleHistogram{
+			AggregationTemporality: otlpCUMULATIVE,
+			DataPoints: []*metric_pb.DoubleHistogramDataPoint{
+				value,
+			},
+		}
+
+		point.Data = &metric_pb.Metric_DoubleHistogram{
+			DoubleHistogram: doubleHist,
+		}
 
 	default:
 		return nil, 0, samples[1:], errors.Errorf("unexpected metric type %s", entry.metadata.MetricType)
@@ -250,8 +270,8 @@ func protoTimeseries(desc *tsDesc) (*metric_pb.ResourceMetrics, *metric_pb.Metri
 		InstrumentationLibraryMetrics: []*metric_pb.InstrumentationLibraryMetrics{
 			&metric_pb.InstrumentationLibraryMetrics{
 				InstrumentationLibrary: &common_pb.InstrumentationLibrary{
-					Name:    "github.com/lightstep/lightstep-prometheus-sidecar",
-					Version: "0.1",
+					Name:    promInstLibrary,
+					Version: promInstVersion,
 				},
 				Metrics: []*metric_pb.Metric{metric},
 			},
@@ -294,181 +314,161 @@ func getNanos(t int64) uint64 {
 	return uint64(time.Duration(t) * time.Millisecond / time.Nanosecond)
 }
 
-// type distribution struct {
-// 	bounds []float64
-// 	values []int64
-// }
+type distribution struct {
+	bounds []float64
+	values []uint64
+}
 
-// func (d *distribution) Len() int {
-// 	return len(d.bounds)
-// }
+func (d *distribution) Len() int {
+	return len(d.bounds)
+}
 
-// func (d *distribution) Less(i, j int) bool {
-// 	return d.bounds[i] < d.bounds[j]
-// }
+func (d *distribution) Less(i, j int) bool {
+	return d.bounds[i] < d.bounds[j]
+}
 
-// func (d *distribution) Swap(i, j int) {
-// 	d.bounds[i], d.bounds[j] = d.bounds[j], d.bounds[i]
-// 	d.values[i], d.values[j] = d.values[j], d.values[i]
-// }
+func (d *distribution) Swap(i, j int) {
+	d.bounds[i], d.bounds[j] = d.bounds[j], d.bounds[i]
+	d.values[i], d.values[j] = d.values[j], d.values[i]
+}
 
-// // buildDistribution consumes series from the beginning of the input slice that belong to a histogram
-// // with the given metric name and label set.
-// // It returns the reset timestamp along with the distrubution.
-// func (b *sampleBuilder) buildDistribution(
-// 	ctx context.Context,
-// 	baseName string,
-// 	matchLset tsdbLabels.Labels,
-// 	samples []tsdb.RefSample,
-// ) (*distribution_pb.Distribution, int64, []tsdb.RefSample, error) {
-// 	var (
-// 		consumed       int
-// 		count, sum     float64
-// 		resetTimestamp int64
-// 		lastTimestamp  int64
-// 		dist           = distribution{bounds: make([]float64, 0, 20), values: make([]int64, 0, 20)}
-// 		skip           = false
-// 	)
-// 	// We assume that all series belonging to the histogram are sequential. Consume series
-// 	// until we hit a new metric.
-// Loop:
-// 	for i, s := range samples {
-// 		e, ok, err := b.series.get(ctx, s.Ref)
-// 		if err != nil {
-// 			return nil, 0, samples, err
-// 		}
-// 		if !ok {
-// 			consumed++
-// 			// TODO(fabxc): increment metric.
-// 			continue
-// 		}
-// 		name := e.lset.Get("__name__")
-// 		// The series matches if it has the same base name, the remainder is a valid histogram suffix,
-// 		// and the labels aside from the le and __name__ label match up.
-// 		if !strings.HasPrefix(name, baseName) || !histogramLabelsEqual(e.lset, matchLset) {
-// 			break
-// 		}
-// 		// In general, a scrape cannot contain the same (set of) series repeatedlty but for different timestamps.
-// 		// It could still happen with bad clients though and we are doing it in tests for simplicity.
-// 		// If we detect the same series as before but for a different timestamp, return the histogram up to this
-// 		// series and leave the duplicate time series untouched on the input.
-// 		if i > 0 && s.T != lastTimestamp {
-// 			break
-// 		}
-// 		lastTimestamp = s.T
+// buildHistogram consumes series from the beginning of the input slice that belong to a histogram
+// with the given metric name and label set.
+// It returns the reset timestamp along with the distrubution.
+func (b *sampleBuilder) buildHistogram(
+	ctx context.Context,
+	baseName string,
+	matchLset tsdbLabels.Labels,
+	samples []tsdb.RefSample,
+) (*metric_pb.DoubleHistogramDataPoint, int64, []tsdb.RefSample, error) {
+	var (
+		consumed       int
+		count, sum     float64
+		resetTimestamp int64
+		lastTimestamp  int64
+		dist           = distribution{bounds: make([]float64, 0, 20), values: make([]uint64, 0, 20)}
+		skip           = false
+	)
+	// We assume that all series belonging to the histogram are sequential. Consume series
+	// until we hit a new metric.
+Loop:
+	for i, s := range samples {
+		e, ok, err := b.series.get(ctx, s.Ref)
+		if err != nil {
+			return nil, 0, samples, err
+		}
+		if !ok {
+			consumed++
+			// TODO(fabxc): increment metric.
+			continue
+		}
+		name := e.lset.Get("__name__")
+		// The series matches if it has the same base name, the remainder is a valid histogram suffix,
+		// and the labels aside from the le and __name__ label match up.
+		if !strings.HasPrefix(name, baseName) || !histogramLabelsEqual(e.lset, matchLset) {
+			break
+		}
+		// In general, a scrape cannot contain the same (set of) series repeatedlty but for different timestamps.
+		// It could still happen with bad clients though and we are doing it in tests for simplicity.
+		// If we detect the same series as before but for a different timestamp, return the histogram up to this
+		// series and leave the duplicate time series untouched on the input.
+		if i > 0 && s.T != lastTimestamp {
+			// TODO: counter
+			break
+		}
+		lastTimestamp = s.T
 
-// 		rt, v, ok := b.series.getResetAdjusted(s.Ref, s.T, s.V)
+		rt, v, ok := b.series.getResetAdjusted(s.Ref, s.T, s.V)
 
-// 		switch name[len(baseName):] {
-// 		case metricSuffixSum:
-// 			sum = v
-// 		case metricSuffixCount:
-// 			count = v
-// 			// We take the count series as the authoritative source for the overall reset timestamp.
-// 			resetTimestamp = rt
-// 		case metricSuffixBucket:
-// 			upper, err := strconv.ParseFloat(e.lset.Get("le"), 64)
-// 			if err != nil {
-// 				consumed++
-// 				// TODO(fabxc): increment metric.
-// 				continue
-// 			}
-// 			dist.bounds = append(dist.bounds, upper)
-// 			dist.values = append(dist.values, int64(v))
-// 		default:
-// 			break Loop
-// 		}
-// 		// If a series appeared for the first time, we won't get a valid reset timestamp yet.
-// 		// This may happen if the histogram is entirely new or if new series appeared through bucket changes.
-// 		// We skip the entire histogram sample in this case.
-// 		if !ok {
-// 			skip = true
-// 		}
-// 		consumed++
-// 	}
-// 	// Don't emit a sample if we explicitly skip it or no reset timestamp was set because the
-// 	// count series was missing.
-// 	if skip || resetTimestamp == 0 {
-// 		return nil, 0, samples[consumed:], nil
-// 	}
-// 	// We do not assume that the buckets in the sample batch are in order, so we sort them again here.
-// 	// The code below relies on this to convert between Prometheus's and Stackdriver's bucketing approaches.
-// 	sort.Sort(&dist)
-// 	// Reuse slices we already populated to build final bounds and values.
-// 	var (
-// 		bounds           = dist.bounds[:0]
-// 		values           = dist.values[:0]
-// 		mean, dev, lower float64
-// 		prevVal          int64
-// 	)
-// 	if count > 0 {
-// 		mean = sum / count
-// 	}
-// 	for i, upper := range dist.bounds {
-// 		if math.IsInf(upper, 1) {
-// 			upper = lower
-// 		} else {
-// 			bounds = append(bounds, upper)
-// 		}
+		switch name[len(baseName):] {
+		case metricSuffixSum:
+			sum = v
+		case metricSuffixCount:
+			count = v
+			// We take the count series as the authoritative source for the overall reset timestamp.
+			resetTimestamp = rt
+		case metricSuffixBucket:
+			upper, err := strconv.ParseFloat(e.lset.Get("le"), 64)
 
-// 		val := dist.values[i] - prevVal
-// 		x := (lower + upper) / 2
-// 		dev += float64(val) * (x - mean) * (x - mean)
+			if err != nil {
+				consumed++
+				// TODO: increment metric.
+				continue
+			}
+			dist.bounds = append(dist.bounds, upper)
+			dist.values = append(dist.values, uint64(v))
+		default:
+			break Loop
+		}
+		// If a series appeared for the first time, we won't get a valid reset timestamp yet.
+		// This may happen if the histogram is entirely new or if new series appeared through bucket changes.
+		// We skip the entire histogram sample in this case.
+		if !ok {
+			skip = true
+		}
+		consumed++
+	}
+	// Don't emit a sample if we explicitly skip it or no reset timestamp was set because the
+	// count series was missing.
+	if skip || resetTimestamp == 0 {
+		return nil, 0, samples[consumed:], nil
+	}
+	// We do not assume that the buckets in the sample batch are in order, so we sort them again here.
+	// The code below relies on this to convert between Prometheus's and Stackdriver's bucketing approaches.
+	sort.Sort(&dist)
+	// Reuse slices we already populated to build final bounds and values.
+	var (
+		values  = dist.values[:0]
+		prevVal uint64
+	)
+	for i := range dist.bounds {
+		val := dist.values[i] - prevVal
+		prevVal = dist.values[i]
+		values = append(values, val)
+	}
+	histogram := &metric_pb.DoubleHistogramDataPoint{
+		Count:          uint64(count),
+		Sum:            sum,
+		BucketCounts:   values,
+		ExplicitBounds: dist.bounds[:len(dist.bounds)-1],
+	}
+	return histogram, resetTimestamp, samples[consumed:], nil
+}
 
-// 		lower = upper
-// 		prevVal = dist.values[i]
-// 		values = append(values, val)
-// 	}
-// 	d := &distribution_pb.Distribution{
-// 		Count:                 int64(count),
-// 		Mean:                  mean,
-// 		SumOfSquaredDeviation: dev,
-// 		BucketOptions: &distribution_pb.Distribution_BucketOptions{
-// 			Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
-// 				ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
-// 					Bounds: bounds,
-// 				},
-// 			},
-// 		},
-// 		BucketCounts: values,
-// 	}
-// 	return d, resetTimestamp, samples[consumed:], nil
-// }
-
-// // histogramLabelsEqual checks whether two label sets for a histogram series are equal aside from their
-// // le and __name__ labels.
-// func histogramLabelsEqual(a, b tsdbLabels.Labels) bool {
-// 	i, j := 0, 0
-// 	for i < len(a) && j < len(b) {
-// 		if a[i].Name == "le" || a[i].Name == "__name__" {
-// 			i++
-// 			continue
-// 		}
-// 		if b[j].Name == "le" || b[j].Name == "__name__" {
-// 			j++
-// 			continue
-// 		}
-// 		if a[i] != b[j] {
-// 			return false
-// 		}
-// 		i++
-// 		j++
-// 	}
-// 	// Consume trailing le and __name__ labels so the check below passes correctly.
-// 	for i < len(a) {
-// 		if a[i].Name == "le" || a[i].Name == "__name__" {
-// 			i++
-// 			continue
-// 		}
-// 		break
-// 	}
-// 	for j < len(b) {
-// 		if b[j].Name == "le" || b[j].Name == "__name__" {
-// 			j++
-// 			continue
-// 		}
-// 		break
-// 	}
-// 	// If one label set still has labels left, they are not equal.
-// 	return i == len(a) && j == len(b)
-// }
+// histogramLabelsEqual checks whether two label sets for a histogram series are equal aside from their
+// le and __name__ labels.
+func histogramLabelsEqual(a, b tsdbLabels.Labels) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i].Name == "le" || a[i].Name == "__name__" {
+			i++
+			continue
+		}
+		if b[j].Name == "le" || b[j].Name == "__name__" {
+			j++
+			continue
+		}
+		if a[i] != b[j] {
+			return false
+		}
+		i++
+		j++
+	}
+	// Consume trailing le and __name__ labels so the check below passes correctly.
+	for i < len(a) {
+		if a[i].Name == "le" || a[i].Name == "__name__" {
+			i++
+			continue
+		}
+		break
+	}
+	for j < len(b) {
+		if b[j].Name == "le" || b[j].Name == "__name__" {
+			j++
+			continue
+		}
+		break
+	}
+	// If one label set still has labels left, they are not equal.
+	return i == len(a) && j == len(b)
+}


### PR DESCRIPTION
Note: The Prometheus histogram representation uses boundaries defined `(lower, upper]` whereas OTLP uses `[lower, upper)`, this minor difference is ignored.