### PR TITLE
Support TLS server certificate, gRPC header options

### DIFF
--- a/cmd/lightstep-prometheus-sidecar/main.go
+++ b/cmd/lightstep-prometheus-sidecar/main.go
@@ -59,6 +59,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -163,7 +164,11 @@ type fileConfig struct {
 }
 
 type securityConfig struct {
-	RootCertificate string `json:"root_certificate"`
+	ServerCertificate string `json:"server_certificate"`
+}
+
+type grpcConfig struct {
+	Headers []string `json:"headers"`
 }
 
 // Note: When adding a new config field, consider adding it to
@@ -190,6 +195,7 @@ type mainConfig struct {
 	MonitoringBackends    []string
 	PromlogConfig         promlog.Config
 	Security              securityConfig
+	GRPC                  grpcConfig
 }
 
 func main() {
@@ -261,8 +267,11 @@ func main() {
 	a.Flag("filter", "PromQL-style matcher for a single label which must pass for a series to be forwarded to Stackdriver. If repeated, the series must pass all filters to be forwarded. Deprecated, please use --include instead.").
 		StringsVar(&cfg.Filters)
 
-	a.Flag("security.root-certificate", "Location of the certificate authority public certificate to use for OTLP connections (e.g., server.crt). If not set, the system root will be used unless the URL has ?auth=false.").
-		StringVar(&cfg.Security.RootCertificate)
+	a.Flag("security.server-certificate", "Public certificate for the server to use for TLS connections (e.g., server.crt, in pem format).").
+		StringVar(&cfg.Security.ServerCertificate)
+
+	a.Flag("grpc.header", "Headers for gRPC connection (e.g., MyHeader=Value1). May be repeated.").
+		StringsVar(&cfg.GRPC.Headers)
 
 	promlogflag.AddFlags(a, &cfg.PromlogConfig)
 
@@ -283,10 +292,21 @@ func main() {
 		}
 	}
 
-	level.Info(logger).Log("msg", "Starting Stackdriver Prometheus sidecar", "version", version.Info())
+	level.Info(logger).Log("msg", "Starting OpenTelemetry Prometheus sidecar", "version", version.Info())
 	level.Info(logger).Log("build_context", version.BuildContext())
 	level.Info(logger).Log("host_details", Uname())
 	level.Info(logger).Log("fd_limits", FdLimits())
+
+	grpcHeadersMap := map[string]string{}
+	for _, hdr := range cfg.GRPC.Headers {
+		kvs := strings.SplitN(hdr, "=", 2)
+		if len(kvs) != 2 {
+			level.Error(logger).Log("msg", "grpc header should have key=value syntax", "ex", hdr)
+			os.Exit(2)
+		}
+		grpcHeadersMap[kvs[0]] = kvs[1]
+	}
+	grpcHeaders := grpcMetadata.New(grpcHeadersMap)
 
 	// We instantiate a context here since the tailer is used by two other components.
 	// The context will be used in the lifecycle of prometheusReader further down.
@@ -431,13 +451,14 @@ func main() {
 			logger: log.With(logger, "component", "storage"),
 		}
 	} else {
-		scf = &stackdriverClientFactory{
+		scf = &otlpClientFactory{
 			logger:            log.With(logger, "component", "storage"),
 			projectIDResource: cfg.ProjectIDResource,
 			url:               cfg.StackdriverAddress,
 			timeout:           10 * time.Second,
 			manualResolver:    cfg.manualResolver,
 			security:          cfg.Security,
+			headers:           grpcHeaders,
 		}
 	}
 
@@ -560,7 +581,7 @@ func main() {
 				if err := queueManager.Start(); err != nil {
 					return err
 				}
-				level.Info(logger).Log("msg", "Stackdriver client started")
+				level.Info(logger).Log("msg", "OpenTelemetry client started")
 				<-cancel
 				return nil
 			},
@@ -601,27 +622,29 @@ func main() {
 	level.Info(logger).Log("msg", "See you next time!")
 }
 
-type stackdriverClientFactory struct {
+type otlpClientFactory struct {
 	logger            log.Logger
 	projectIDResource string
 	url               *url.URL
 	timeout           time.Duration
 	manualResolver    *manual.Resolver
 	security          securityConfig
+	headers           grpcMetadata.MD
 }
 
-func (s *stackdriverClientFactory) New() otlp.StorageClient {
+func (s *otlpClientFactory) New() otlp.StorageClient {
 	return otlp.NewClient(&otlp.ClientConfig{
-		Logger:     s.logger,
-		ProjectID:  s.projectIDResource,
-		URL:        s.url,
-		Timeout:    s.timeout,
-		Resolver:   s.manualResolver,
-		CACertFile: s.security.RootCertificate,
+		Logger:    s.logger,
+		ProjectID: s.projectIDResource,
+		URL:       s.url,
+		Timeout:   s.timeout,
+		Resolver:  s.manualResolver,
+		CertFile:  s.security.ServerCertificate,
+		Headers:   s.headers,
 	})
 }
 
-func (s *stackdriverClientFactory) Name() string {
+func (s *otlpClientFactory) Name() string {
 	return s.url.String()
 }
 

--- a/cmd/lightstep-prometheus-sidecar/statusz-tmpl.html
+++ b/cmd/lightstep-prometheus-sidecar/statusz-tmpl.html
@@ -80,7 +80,6 @@
       <tr><th>Use GKE resource</th><td>{{.UseGKEResource}}</td></tr>
       <tr><th>Use restricted IPs</th><td>{{.UseRestrictedIPs}}</td></tr>
       <tr><th>WAL directory</th><td>{{.WALDirectory}}</td></tr>
-      <tr><th>CA Cert file</th><td>{{.CACertFile}}</td></tr>
     </table>
 
     <h2>Aggregations</h2>

--- a/cmd/lightstep-prometheus-sidecar/statusz-tmpl.html
+++ b/cmd/lightstep-prometheus-sidecar/statusz-tmpl.html
@@ -80,6 +80,7 @@
       <tr><th>Use GKE resource</th><td>{{.UseGKEResource}}</td></tr>
       <tr><th>Use restricted IPs</th><td>{{.UseRestrictedIPs}}</td></tr>
       <tr><th>WAL directory</th><td>{{.WALDirectory}}</td></tr>
+      <tr><th>CA Cert file</th><td>{{.CACertFile}}</td></tr>
     </table>
 
     <h2>Aggregations</h2>

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -16,7 +16,9 @@ package otlp
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
 	"strconv"
@@ -32,7 +34,6 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
 
@@ -43,7 +44,6 @@ import (
 
 const (
 	MaxTimeseriesesPerRequest = 200
-	MonitoringWriteScope      = "https://www.googleapis.com/auth/monitoring.write"
 )
 
 var (
@@ -71,22 +71,24 @@ func init() {
 // implementation may hit a single backend, so the application should create a
 // number of these clients.
 type Client struct {
-	logger    log.Logger
-	projectID string
-	url       *url.URL
-	timeout   time.Duration
-	resolver  *manual.Resolver
+	logger     log.Logger
+	projectID  string
+	url        *url.URL
+	timeout    time.Duration
+	resolver   *manual.Resolver
+	caCertFile string
 
 	conn *grpc.ClientConn
 }
 
 // ClientConfig configures a Client.
 type ClientConfig struct {
-	Logger    log.Logger
-	ProjectID string // The Stackdriver project ID in "projects/name-or-number" format.
-	URL       *url.URL
-	Timeout   time.Duration
-	Resolver  *manual.Resolver
+	Logger     log.Logger
+	ProjectID  string // The Stackdriver project ID in "projects/name-or-number" format.
+	URL        *url.URL
+	Timeout    time.Duration
+	Resolver   *manual.Resolver
+	CACertFile string
 }
 
 // NewClient creates a new Client.
@@ -96,11 +98,12 @@ func NewClient(conf *ClientConfig) *Client {
 		logger = log.NewNopLogger()
 	}
 	return &Client{
-		logger:    logger,
-		projectID: conf.ProjectID,
-		url:       conf.URL,
-		timeout:   conf.Timeout,
-		resolver:  conf.Resolver,
+		logger:     logger,
+		projectID:  conf.ProjectID,
+		url:        conf.URL,
+		timeout:    conf.Timeout,
+		resolver:   conf.Resolver,
+		caCertFile: conf.CACertFile,
 	}
 }
 
@@ -109,7 +112,7 @@ type recoverableError struct {
 }
 
 // version.* is populated for 'promu' builds, so this will look broken in unit tests.
-var userAgent = fmt.Sprintf("StackdriverPrometheus/%s", version.Version)
+var userAgent = fmt.Sprintf("LightstepPrometheus/%s", version.Version)
 
 func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 	if c.conn != nil {
@@ -134,14 +137,25 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
 	}
 	if useAuth {
-		rpcCreds, err := oauth.NewApplicationDefault(context.Background(), MonitoringWriteScope)
-		if err != nil {
-			return nil, err
+		var tcfg tls.Config
+		if c.caCertFile != "" {
+			certPool := x509.NewCertPool()
+			bs, err := ioutil.ReadFile(c.caCertFile)
+			if err != nil {
+				return nil, fmt.Errorf("could not read certificate authority certificate: %s: %w", c.caCertFile, err)
+			}
+
+			ok := certPool.AppendCertsFromPEM(bs)
+			if !ok {
+				return nil, fmt.Errorf("could not parse certificate authority certificate: %s: %w", c.caCertFile, err)
+			}
+
+			tcfg = tls.Config{
+				ServerName: c.url.Hostname(),
+				RootCAs:    certPool,
+			}
 		}
-		tlsCreds := credentials.NewTLS(&tls.Config{})
-		dopts = append(dopts,
-			grpc.WithTransportCredentials(tlsCreds),
-			grpc.WithPerRPCCredentials(rpcCreds))
+		dopts = append(dopts, grpc.WithTransportCredentials(credentials.NewTLS(&tcfg)))
 	} else {
 		dopts = append(dopts, grpc.WithInsecure())
 	}

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -21,9 +21,6 @@ import (
 	"strings"
 	"time"
 
-	common_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
-	metric_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
-	resource_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/resource/v1"
 	"github.com/lightstep/lightstep-prometheus-sidecar/metadata"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/version"
@@ -31,6 +28,10 @@ import (
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/tsdb"
 	tsdbLabels "github.com/prometheus/tsdb/labels"
+
+	common_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
+	metric_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
+	resource_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/resource/v1"
 )
 
 const (

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -21,23 +21,22 @@ import (
 	"strings"
 	"time"
 
+	common_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
+	metric_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
+	resource_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/resource/v1"
 	"github.com/lightstep/lightstep-prometheus-sidecar/metadata"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/tsdb"
 	tsdbLabels "github.com/prometheus/tsdb/labels"
-
-	common_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
-	metric_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
-	resource_pb "github.com/lightstep/lightstep-prometheus-sidecar/internal/opentelemetry-proto-gen/resource/v1"
 )
 
 const (
 	otlpCUMULATIVE = metric_pb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
 
 	promInstLibrary = "github.com/lightstep/lightstep-prometheus-sidecar"
-	promInstVersion = "0.1"
 )
 
 // Appender appends a time series with exactly one data point. A hash for the series
@@ -229,7 +228,7 @@ func protoTimeseries(desc *tsDesc) (*metric_pb.ResourceMetrics, *metric_pb.Metri
 			&metric_pb.InstrumentationLibraryMetrics{
 				InstrumentationLibrary: &common_pb.InstrumentationLibrary{
 					Name:    promInstLibrary,
-					Version: promInstVersion,
+					Version: version.Version,
 				},
 				Metrics: []*metric_pb.Metric{metric},
 			},


### PR DESCRIPTION
This supports basic authorization using an access token header, for example, instead of the SD oauth flow.