### PR TITLE
Target label discovery: bug fix, testing, and use-meta-labels option

### DIFF
--- a/cmd/lightstep-prometheus-sidecar/main.go
+++ b/cmd/lightstep-prometheus-sidecar/main.go
@@ -298,10 +298,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	targetCache := targets.NewCache(logger, httpClient, targetsURL)
 
 	resAttrMap := map[string]string{}
-
 	for _, attr := range cfg.Resource.Attributes {
 		kvs := strings.SplitN(attr, "=", 2)
 		if len(kvs) != 2 {
@@ -311,7 +309,7 @@ func main() {
 		resAttrMap[kvs[0]] = kvs[1]
 	}
 
-	targetCacheWithLabels := retrieval.TargetsWithDiscoveredLabels(targetCache, labels.FromMap(resAttrMap))
+	targetCache := targets.NewCache(logger, httpClient, targetsURL, labels.FromMap(resAttrMap))
 
 	metadataURL, err := cfg.PrometheusURL.Parse(metadata.DefaultEndpointPath)
 	if err != nil {
@@ -357,7 +355,7 @@ func main() {
 		tailer,
 		filtersets,
 		cfg.MetricRenames,
-		targetCacheWithLabels,
+		targetCache,
 		metadataCache,
 		queueManager,
 		cfg.MetricsPrefix,

--- a/cmd/lightstep-prometheus-sidecar/main.go
+++ b/cmd/lightstep-prometheus-sidecar/main.go
@@ -151,8 +151,8 @@ type grpcConfig struct {
 }
 
 type resourceConfig struct {
-	Attributes         []string `json:"attributes"`
-	UseDiscoveryLabels bool     `json:"use_discovery_labels"`
+	Attributes    []string `json:"attributes"`
+	UseMetaLabels bool     `json:"use_meta_labels"`
 }
 
 type mainConfig struct {
@@ -220,8 +220,8 @@ func main() {
 	a.Flag("resource.attribute", "Attributes for exported metrics (e.g., MyResource=Value1). May be repeated.").
 		StringsVar(&cfg.Resource.Attributes)
 
-	a.Flag("resource.use-discovery-labels", "Map Prometheus target labels prefixed with __meta_ into labels.").
-		BoolVar(&cfg.Resource.UseDiscoveryLabels)
+	a.Flag("resource.use-meta-labels", "Prometheus target labels prefixed with __meta_ map into labels.").
+		BoolVar(&cfg.Resource.UseMetaLabels)
 
 	promlogflag.AddFlags(a, &cfg.PromlogConfig)
 
@@ -318,7 +318,7 @@ func main() {
 		httpClient,
 		targetsURL,
 		labels.FromMap(resAttrMap),
-		cfg.Resource.UseDiscoveryLabels,
+		cfg.Resource.UseMetaLabels,
 	)
 
 	metadataURL, err := cfg.PrometheusURL.Parse(metadata.DefaultEndpointPath)

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -221,6 +221,7 @@ func (c *Client) Store(req *metricsService.ExportMetricsServiceRequest) error {
 					"msg", "Write was successful",
 					"records", end-begin)
 			} else {
+				// TODO This happens too fast _after_ a healthy connection becomes unhealthy. Fix.
 				level.Debug(c.logger).Log(
 					"msg", "Partial failure calling Export",
 					"err", err)

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -47,6 +47,7 @@ type targetsWithDiscoveredLabels struct {
 
 // TargetsWithDiscoveredLabels wraps a TargetGetter and adds a static set of labels to the discovered
 // labels of all targets retrieved from it.
+// TODO: Move this into an option in the constructor of targets.Cache, it's inefficient to sort on read.
 func TargetsWithDiscoveredLabels(tg TargetGetter, lset labels.Labels) TargetGetter {
 	return &targetsWithDiscoveredLabels{TargetGetter: tg, lset: lset}
 }

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -38,29 +37,6 @@ import (
 
 type TargetGetter interface {
 	Get(ctx context.Context, lset labels.Labels) (*targets.Target, error)
-}
-
-type targetsWithDiscoveredLabels struct {
-	TargetGetter
-	lset labels.Labels
-}
-
-// TargetsWithDiscoveredLabels wraps a TargetGetter and adds a static set of labels to the discovered
-// labels of all targets retrieved from it.
-// TODO: Move this into an option in the constructor of targets.Cache, it's inefficient to sort on read.
-func TargetsWithDiscoveredLabels(tg TargetGetter, lset labels.Labels) TargetGetter {
-	return &targetsWithDiscoveredLabels{TargetGetter: tg, lset: lset}
-}
-
-func (tg *targetsWithDiscoveredLabels) Get(ctx context.Context, lset labels.Labels) (*targets.Target, error) {
-	t, err := tg.TargetGetter.Get(ctx, lset)
-	if err != nil || t == nil {
-		return t, err
-	}
-	repl := *t
-	repl.DiscoveredLabels = append(append(labels.Labels{}, t.DiscoveredLabels...), tg.lset...)
-	sort.Sort(repl.DiscoveredLabels)
-	return &repl, nil
 }
 
 type MetadataGetter interface {

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -210,22 +209,6 @@ func TestReader_ProgressFile(t *testing.T) {
 	}
 	if offset != 12345 {
 		t.Fatalf("expected progress offset %d but got %d", 12345, offset)
-	}
-}
-
-func TestTargetsWithDiscoveredLabels(t *testing.T) {
-	tm := targetMap{
-		"/": &targets.Target{DiscoveredLabels: promlabels.FromStrings("b", "2")},
-	}
-
-	wrapped := TargetsWithDiscoveredLabels(tm, promlabels.FromStrings("a", "1", "c", "3"))
-
-	target, err := wrapped.Get(context.Background(), promlabels.FromStrings("b", "2"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(target.DiscoveredLabels, promlabels.FromStrings("a", "1", "b", "2", "c", "3")) {
-		t.Fatalf("unexpected discovered labels %s", target.DiscoveredLabels)
 	}
 }
 

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -42,17 +42,18 @@ func cacheKey(job, instance string) string {
 // by a varying set of labels within a job and instance combination.
 // Implements TargetGetter.
 type Cache struct {
-	logger      log.Logger
-	client      *http.Client
-	url         *url.URL
-	extraLabels labels.Labels
+	logger             log.Logger
+	client             *http.Client
+	url                *url.URL
+	extraLabels        labels.Labels
+	useDiscoveryLabels bool
 
 	mtx sync.RWMutex
 	// Targets indexed by job/instance combination.
 	targets map[string][]*Target
 }
 
-func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLabels labels.Labels) *Cache {
+func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLabels labels.Labels, useDiscoveryLabels bool) *Cache {
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -60,11 +61,12 @@ func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLab
 		logger = log.NewNopLogger()
 	}
 	return &Cache{
-		logger:      logger,
-		client:      client,
-		url:         promURL,
-		extraLabels: extraLabels,
-		targets:     map[string][]*Target{},
+		logger:             logger,
+		client:             client,
+		url:                promURL,
+		extraLabels:        extraLabels,
+		useDiscoveryLabels: useDiscoveryLabels,
+		targets:            map[string][]*Target{},
 	}
 }
 
@@ -191,11 +193,17 @@ func (c *Cache) Get(ctx context.Context, lset labels.Labels) (*Target, error) {
 	// Add the now-unique target labels back into discovered labels.
 	t.DiscoveredLabels = append(t.DiscoveredLabels, t.Labels...)
 
-	// TODO: Option to: Remap __meta_
-
 	// Remove __ prefixes from DiscoveredLabels.
 	tmp := t.DiscoveredLabels[:0]
 	for _, l := range t.DiscoveredLabels {
+		if c.useDiscoveryLabels && strings.HasPrefix(l.Name, "__meta_") {
+			tmp = append(tmp, labels.Label{
+				Name:  l.Name[len("__meta_"):],
+				Value: l.Value,
+			})
+			continue
+		}
+
 		if !strings.HasPrefix(l.Name, "__") {
 			tmp = append(tmp, l)
 		}

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -178,15 +178,26 @@ func (c *Cache) Get(ctx context.Context, lset labels.Labels) (*Target, error) {
 	t, _ := targetMatch(ts, lset)
 
 	if t != nil {
+		// Remove target labels from DiscoveredLabels.
+		t.DiscoveredLabels = DropTargetLabels(t.DiscoveredLabels, t.Labels)
+
+		// Add the now-unique target labels back into
+		// discovered labels.  These will all be exported as
+		// resources.  (TODO: along with those injected on the
+		// command-line, which should just be sorted-in here.)
+		// TODO: Fix the tests after this:
+		t.DiscoveredLabels = append(t.DiscoveredLabels, t.Labels...)
+
+		// TODO: Option to: Remap __meta_
+
 		// Remove __ prefixes from DiscoveredLabels.
-		o := 0
+		tmp := t.DiscoveredLabels[:0]
 		for _, l := range t.DiscoveredLabels {
 			if !strings.HasPrefix(l.Name, "__") {
-				t.DiscoveredLabels[o] = l
-				o++
+				tmp = append(tmp, l)
 			}
 		}
-		t.DiscoveredLabels = t.DiscoveredLabels[:o]
+		t.DiscoveredLabels = tmp
 	}
 	return t, nil
 }

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -42,18 +42,18 @@ func cacheKey(job, instance string) string {
 // by a varying set of labels within a job and instance combination.
 // Implements TargetGetter.
 type Cache struct {
-	logger             log.Logger
-	client             *http.Client
-	url                *url.URL
-	extraLabels        labels.Labels
-	useDiscoveryLabels bool
+	logger        log.Logger
+	client        *http.Client
+	url           *url.URL
+	extraLabels   labels.Labels
+	useMetaLabels bool
 
 	mtx sync.RWMutex
 	// Targets indexed by job/instance combination.
 	targets map[string][]*Target
 }
 
-func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLabels labels.Labels, useDiscoveryLabels bool) *Cache {
+func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLabels labels.Labels, useMetaLabels bool) *Cache {
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -61,12 +61,12 @@ func NewCache(logger log.Logger, client *http.Client, promURL *url.URL, extraLab
 		logger = log.NewNopLogger()
 	}
 	return &Cache{
-		logger:             logger,
-		client:             client,
-		url:                promURL,
-		extraLabels:        extraLabels,
-		useDiscoveryLabels: useDiscoveryLabels,
-		targets:            map[string][]*Target{},
+		logger:        logger,
+		client:        client,
+		url:           promURL,
+		extraLabels:   extraLabels,
+		useMetaLabels: useMetaLabels,
+		targets:       map[string][]*Target{},
 	}
 }
 
@@ -196,7 +196,7 @@ func (c *Cache) Get(ctx context.Context, lset labels.Labels) (*Target, error) {
 	// Remove __ prefixes from DiscoveredLabels.
 	tmp := t.DiscoveredLabels[:0]
 	for _, l := range t.DiscoveredLabels {
-		if c.useDiscoveryLabels && strings.HasPrefix(l.Name, "__meta_") {
+		if c.useMetaLabels && strings.HasPrefix(l.Name, "__meta_") {
 			tmp = append(tmp, labels.Label{
 				Name:  l.Name[len("__meta_"):],
 				Value: l.Value,

--- a/targets/cache_test.go
+++ b/targets/cache_test.go
@@ -39,7 +39,7 @@ func TestTargetCache_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := NewCache(nil, nil, u, nil)
+	c := NewCache(nil, nil, u, nil, false)
 
 	expectedTarget := &Target{
 		Labels: labels.FromStrings("job", "a", "instance", "c"),
@@ -85,26 +85,27 @@ func TestTargetCache_Error(t *testing.T) {
 	}
 }
 
-func TestTargetCache_Success(t *testing.T) {
-	var handler func() []*Target
-
+func cacheForHandlerFunc(t *testing.T, handlerP *func() []*Target, extra labels.Labels, useMeta bool) *Cache {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var resp apiResponse
 		resp.Status = "success"
-		resp.Data.ActiveTargets = handler()
+		resp.Data.ActiveTargets = (*handlerP)()
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatal(err)
 		}
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	u, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := NewCache(nil, nil, u, nil)
+	return NewCache(nil, nil, u, extra, useMeta)
+}
+
+func TestTargetCache_Success(t *testing.T) {
+	var handler func() []*Target
+
+	c := cacheForHandlerFunc(t, &handler, nil, false)
 
 	handler = func() []*Target {
 		return []*Target{
@@ -118,6 +119,10 @@ func TestTargetCache_Success(t *testing.T) {
 			{Labels: labels.FromStrings("job", "job2", "instance", "instance1", "port", "port2")},
 		}
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	target1, err := c.Get(ctx, labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "instance1"))
 	if err != nil {
 		t.Fatal(err)
@@ -208,24 +213,8 @@ func TestTargetCache_Success(t *testing.T) {
 func TestTargetCache_EmptyEntry(t *testing.T) {
 	var handler func() []*Target
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var resp apiResponse
-		resp.Status = "success"
-		resp.Data.ActiveTargets = handler()
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			t.Fatal(err)
-		}
-	}))
+	c := cacheForHandlerFunc(t, &handler, nil, false)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c := NewCache(nil, nil, u, nil)
 	// Initialize cache with negative-cached target.
 	c.targets[cacheKey("job1", "instance-not-exists")] = nil
 
@@ -233,6 +222,10 @@ func TestTargetCache_EmptyEntry(t *testing.T) {
 	handler = func() []*Target {
 		return []*Target{}
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	c.Get(ctx, labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "instance1"))
 
 	// Empty entry should be kept in cache.
@@ -299,5 +292,80 @@ func TestDropTargetLabels(t *testing.T) {
 		if got := DropTargetLabels(c.series, c.target); !labelsEqual(got, c.result) {
 			t.Fatalf("expected %s for series %s and target %s but got %s", c.result, c.series, c.target, got)
 		}
+	}
+}
+
+func TestLabelDiscovery(t *testing.T) {
+	type testKase struct {
+		name string
+
+		ident   labels.Labels
+		disco   labels.Labels
+		extra   labels.Labels
+		useMeta bool
+
+		expect labels.Labels
+	}
+
+	kases := []testKase{
+		{
+			name:    "small test",
+			ident:   labels.FromStrings("job", "J", "instance", "I"),
+			disco:   labels.FromStrings("job", "J", "node", "A", "__address__", "3000"),
+			extra:   labels.FromStrings("env", "X"),
+			useMeta: false,
+			expect:  labels.FromStrings("job", "J", "instance", "I", "node", "A", "env", "X"),
+		},
+		{
+			name:    "large test",
+			ident:   labels.FromStrings("job", "J", "instance", "I"),
+			disco:   labels.FromStrings("job", "J", "node", "A", "pod", "P", "__ignore__", "G", "__nothing__", "here"),
+			extra:   labels.FromStrings("env", "X", "channel", "C"),
+			useMeta: false,
+			expect:  labels.FromStrings("job", "J", "instance", "I", "node", "A", "env", "X", "channel", "C", "pod", "P"),
+		},
+		{
+			name:    "useMeta test",
+			ident:   labels.FromStrings("job", "J", "instance", "I"),
+			disco:   labels.FromStrings("__meta_something", "S", "__meta_other", "O"),
+			extra:   labels.FromStrings(),
+			useMeta: true,
+			expect:  labels.FromStrings("job", "J", "instance", "I", "something", "S", "other", "O"),
+		},
+	}
+
+	for _, kase := range kases {
+		t.Run(kase.name, func(t *testing.T) {
+			var handler func() []*Target
+
+			c := cacheForHandlerFunc(t, &handler, kase.extra, kase.useMeta)
+
+			handler = func() []*Target {
+				return []*Target{
+					{Labels: kase.ident, DiscoveredLabels: kase.disco},
+				}
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tgt, err := c.Get(
+				ctx,
+				labels.FromStrings(
+					"__name__", "metric1",
+					"job", kase.ident.Get("job"),
+					"instance", kase.ident.Get("instance"),
+				),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !labelsEqual(tgt.Labels, kase.ident) {
+				t.Fatalf("unexpected target labels %v != %v", tgt.Labels, kase.ident)
+			}
+			if !labelsEqual(tgt.DiscoveredLabels, kase.expect) {
+				t.Fatalf("unexpected discovered target labels %v != %v", tgt.DiscoveredLabels, kase.expect)
+			}
+		})
 	}
 }

--- a/targets/cache_test.go
+++ b/targets/cache_test.go
@@ -39,7 +39,7 @@ func TestTargetCache_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := NewCache(nil, nil, u)
+	c := NewCache(nil, nil, u, nil)
 
 	expectedTarget := &Target{
 		Labels: labels.FromStrings("job", "a", "instance", "c"),
@@ -104,7 +104,7 @@ func TestTargetCache_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := NewCache(nil, nil, u)
+	c := NewCache(nil, nil, u, nil)
 
 	handler = func() []*Target {
 		return []*Target{
@@ -125,7 +125,7 @@ func TestTargetCache_Success(t *testing.T) {
 	if !labelsEqual(target1.Labels, labels.FromStrings("job", "job1", "instance", "instance1")) {
 		t.Fatalf("unexpected target labels %s", target1.Labels)
 	}
-	if !labelsEqual(target1.DiscoveredLabels, labels.FromStrings("something", "else")) {
+	if !labelsEqual(target1.DiscoveredLabels, labels.FromStrings("instance", "instance1", "job", "job1", "something", "else")) {
 		t.Fatalf("unexpected discovered target labels %s", target1.DiscoveredLabels)
 	}
 	// Get a non-existant target. The first time it should attempt a refresh.
@@ -225,7 +225,7 @@ func TestTargetCache_EmptyEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := NewCache(nil, nil, u)
+	c := NewCache(nil, nil, u, nil)
 	// Initialize cache with negative-cached target.
 	c.targets[cacheKey("job1", "instance-not-exists")] = nil
 


### PR DESCRIPTION
The bug was introduced in PR #2. Some labels target labels were being dropped.

Discovered labels (existing terminology) are mapped into resources (OpenTelemetry terminology) as follows:

- merge unique `target.Labels` with additional `target.DiscoveredLabels`: there are redundancies between these having to do with Prometheus label rewriting and `__address__`
- add extra labels passed using `--resource.attribute=KEY=VALUE`
- drop label names starting with `__`
- except if `--resource.use-meta-labels` is set, map label names starting `__meta_`, as if by a Prometheus relabeling:

```
  relabel_configs:
  - action: labelmap
    regex: __meta_(.+)
```
