### PR TITLE
Fix a race in TestReader_Progress

### DIFF
--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"sync"
 	"testing"
 	"time"
 


### PR DESCRIPTION
The lock was added before merging the prior PR, before CircleCI would have caught this bug. :-)