### PR TITLE
Replace direct Prometheus instrumentation w/ OTel metrics

### DIFF
--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -98,7 +98,7 @@ type QueueManager struct {
 	sentBatchDuration     metric.Float64ValueRecorder
 	queueLengthCounter    metric.Int64UpDownCounter
 	queueCapacityObs      metric.Int64SumObserver
-	numShardsObs          metric.Int64SumObserver
+	numShardsObs          metric.Int64UpDownSumObserver
 }
 
 // NewQueueManager builds a new QueueManager.
@@ -166,7 +166,7 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, clientFactory St
 			"The capacity of the queue of samples to be sent to the remote storage.",
 		),
 	)
-	t.numShardsObs = sidecar.OTelMeterMust.NewInt64SumObserver(
+	t.numShardsObs = sidecar.OTelMeterMust.NewInt64UpDownSumObserver(
 		"export.queue.shards",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			result.Observe(int64(t.numShards))

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -344,9 +344,6 @@ func (t *QueueManager) reshardLoop() {
 }
 
 func (t *QueueManager) reshard(n int) {
-	// @@@
-	// numShards.WithLabelValues(t.queueName).Set(float64(n))
-
 	t.shardsMtx.Lock()
 	newShards := t.newShardCollection(n)
 	oldShards := t.shards


### PR DESCRIPTION
Removes lingering commented-out direct Prometheus instrumentation in favor of direct OTel metrics instrumentation.

Part of #23.
