### PR TITLE
Metric naming consistency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+### Added
+
+### Changed
+
+- Change several metric names to use `.` instead of `_` for 
+  OpenTelemetry consistency.
+
+### Removed
+
+### Fixed
+
+## [0.2.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.2.0) - 2020-10-20
 
 ### Added
 

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	pointsExported = sidecar.OTelMeterMust.NewInt64Counter(
-		"points_exported",
+		"points.exported",
 		metric.WithDescription("count of exported metric points"),
 	)
 )

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -36,12 +36,12 @@ import (
 
 var (
 	samplesProcessed = sidecar.OTelMeterMust.NewInt64ValueRecorder(
-		"samples_processed",
+		"samples.processed",
 		metric.WithDescription("Number of WAL samples processed in a batch"),
 	)
 
 	samplesProduced = sidecar.OTelMeterMust.NewInt64Counter(
-		"samples_produced",
+		"samples.produced",
 		metric.WithDescription("Number of Metric samples produced"),
 	)
 )

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	droppedSeries = sidecar.OTelMeterMust.NewInt64Counter(
-		"dropped_series",
+		"dropped.series",
 		metric.WithDescription("Number of series that were dropped, not exported"),
 	)
 	keyReason = label.Key("key_reason")


### PR DESCRIPTION
OpenTelemetry metrics prefer `.` to `_`.
This PR fixes the code here to use consistent `.` style.