### PR TITLE
Add a missing internal (i.e., synthetic) metric name

### DIFF
--- a/metadata/cache.go
+++ b/metadata/cache.go
@@ -274,6 +274,11 @@ var internalMetrics = map[string]*Entry{
 		MetricType: textparse.MetricTypeGauge,
 		ValueType:  DOUBLE,
 		Help:       "How many samples were ingested after relabeling"},
+	"scrape_series_added": &Entry{
+		Metric:     "scrape_series_added",
+		MetricType: textparse.MetricTypeGauge,
+		ValueType:  DOUBLE,
+		Help:       "Number of new series in the last successful scrape"},
 }
 
 type apiResponse struct {

--- a/metadata/cache_test.go
+++ b/metadata/cache_test.go
@@ -149,14 +149,16 @@ func TestCache_Get(t *testing.T) {
 	expect(apiMetadata{Metric: "metric6", Type: textparse.MetricTypeUnknown, Help: "help_metric6"}, md)
 
 	// The scrape layer's metrics should not fire off requests.
-	md, err = c.Get(ctx, "prometheus", "localhost:9090", "up")
+	for _, internalName := range []string{"up", "scrape_series_added"} {
+	md, err = c.Get(ctx, "prometheus", "localhost:9090", internalName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(internalMetrics["up"], md) {
-		t.Errorf("unexpected metadata %v, want %v", *md, internalMetrics["up"])
+	if !reflect.DeepEqual(internalMetrics[internalName], md) {
+		t.Errorf("unexpected metadata %v, want %v", *md, internalMetrics[internalName])
 	}
-
+	}
+	
 	// If a metric does not exist, we first expect a fetch attempt.
 	handler = func(qMetric, qMatch string) *apiResponse {
 		if qMetric != "does_not_exist" {


### PR DESCRIPTION
There are 5 documented internal metric names, but only four were handled in the metadata cache as special cases. 

https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series

It appears that new versions of Prometheus will return metadata for these series, but this fix appears to be needed in recent but still supported versions of the sidecar.