### PR TITLE
Truncate error messages; they were very long from the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Change several metric names to use `.` instead of `_` for 
-  OpenTelemetry consistency.
-- Update to OpenTelemetry-Go SDK version 0.14.
+  OpenTelemetry consistency. (#43)
+- Update to OpenTelemetry-Go SDK version 0.14. (#41)
+- Removed unnecessary code that reduced batching capability. (#45)
+- Truncate server error messages to 256 bytes. (#46)
 
 ### Removed
 

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -205,8 +205,8 @@ func (c *Client) Store(req *metricsService.ExportMetricsServiceRequest) error {
 			} else {
 				// TODO This happens too fast _after_ a healthy connection becomes unhealthy. Fix.
 				level.Debug(c.logger).Log(
-					"msg", "Partial failure calling Export",
-					"err", err)
+					"msg", "Failure calling Export",
+					"err", truncateErrorString(err))
 				status, ok := status.FromError(err)
 				// TODO metrics
 				if !ok {

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -51,7 +51,7 @@ const (
 	logRateLimit = 0.1
 	logBurst     = 10
 
-	maxErrorDetailStringLen = 256
+	maxErrorDetailStringLen = 512
 
 	queueName = label.Key("queue")
 )

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"sync"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc/status"
 
 	// gRPC Status protobuf types we may want to see.  This type
 	// is not widely used, but is the most standard way to itemize
@@ -52,6 +50,8 @@ const (
 	// Limit to 1 log event every 10s
 	logRateLimit = 0.1
 	logBurst     = 10
+
+	maxErrorDetailStringLen = 256
 
 	queueName = label.Key("queue")
 )
@@ -498,27 +498,11 @@ func (s *shardCollection) sendSamplesWithBackoff(client StorageClient, samples [
 			return
 		}
 
-		var detailStrings []string
-
-		if code, ok := status.FromError(err); ok {
-			details := code.Details()
-
-			if len(details) != 0 {
-				for _, det := range details {
-					detailStrings = append(detailStrings, fmt.Sprint(det))
-				}
-			}
-		}
-
 		if _, ok := err.(recoverableError); !ok {
-			logArgs := []interface{}{
+			level.Warn(s.qm.logger).Log(
 				"msg", "unrecoverable write error",
-				"err", err,
-			}
-			if detailStrings != nil {
-				logArgs = append(logArgs, "detail", strings.Join(detailStrings, ", "))
-			}
-			level.Warn(s.qm.logger).Log(logArgs...)
+				"err", truncateErrorString(err),
+			)
 			break
 		}
 		time.Sleep(time.Duration(backoff))
@@ -533,4 +517,14 @@ func (s *shardCollection) sendSamplesWithBackoff(client StorageClient, samples [
 		int64(len(samples)),
 		queueName.String(s.qm.queueName),
 	)
+}
+
+// truncateErrorString avoids printing error messages that are very
+// large.
+func truncateErrorString(err error) string {
+	tmp := fmt.Sprint(err)
+	if len(tmp) > maxErrorDetailStringLen {
+		tmp = fmt.Sprint(tmp[:maxErrorDetailStringLen], " ...")
+	}
+	return tmp
 }


### PR DESCRIPTION
Error messages from badly behaving backends can deluge the logs with error messages. This improves the situation.