### PR TITLE
Implement a max-point-age flag and config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update to OpenTelemetry-Go SDK version 0.14. (#41)
 - Removed unnecessary code that reduced batching capability. (#45)
 - Truncate server error messages to 256 bytes. (#46)
+- Implement `--prometheus.max-point-age` flag, default 25h. (#47)
 
 ### Removed
 

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -230,6 +230,7 @@ func main() {
 		metadataCache,
 		queueManager,
 		cfg.OpenTelemetry.MetricsPrefix,
+		cfg.Prometheus.MaxPointAge.Duration,
 	)
 
 	// Monitor outgoing connections on default transport with conntrack.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ const (
 	DefaultWALDirectory       = "data/wal"
 	DefaultAdminListenAddress = "0.0.0.0:9091"
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"
+	DefaultMaxPointAge        = time.Hour * 25
 
 	briefDescription = `
 The OpenTelemetry Prometheus sidecar runs alongside the
@@ -75,8 +76,9 @@ type LogConfig struct {
 }
 
 type PromConfig struct {
-	Endpoint string `json:"endpoint"`
-	WAL      string `json:"wal"`
+	Endpoint    string         `json:"endpoint"`
+	WAL         string         `json:"wal"`
+	MaxPointAge DurationConfig `json:"max_point_age"`
 }
 
 type OTelConfig struct {
@@ -114,8 +116,9 @@ type FileReadFunc func(filename string) ([]byte, error)
 func DefaultMainConfig() MainConfig {
 	return MainConfig{
 		Prometheus: PromConfig{
-			WAL:      DefaultWALDirectory,
-			Endpoint: DefaultPrometheusEndpoint,
+			WAL:         DefaultWALDirectory,
+			Endpoint:    DefaultPrometheusEndpoint,
+			MaxPointAge: DurationConfig{DefaultMaxPointAge},
 		},
 		Admin: AdminConfig{
 			ListenAddress: DefaultAdminListenAddress,
@@ -175,6 +178,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag("prometheus.endpoint", "Endpoint where Prometheus hosts its  UI, API, and serves its own metrics. Default: "+DefaultPrometheusEndpoint).
 		StringVar(&cfg.Prometheus.Endpoint)
+
+	a.Flag("prometheus.max-point-age", "Skip points older than this, to assist recovery. Default: "+DefaultMaxPointAge.String()).
+		DurationVar(&cfg.Prometheus.MaxPointAge.Duration)
 
 	a.Flag("admin.listen-address", "Administrative HTTP address this process listens on. Default: "+DefaultAdminListenAddress).
 		StringVar(&cfg.Admin.ListenAddress)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,9 @@ startup_delay: 1333s
 				Prometheus: PromConfig{
 					WAL:      "wal-eeee",
 					Endpoint: config.DefaultPrometheusEndpoint,
+					MaxPointAge: DurationConfig{
+						25 * time.Hour,
+					},
 				},
 				Admin: AdminConfig{
 					ListenAddress: config.DefaultAdminListenAddress,
@@ -239,6 +242,9 @@ log_config:
 				Prometheus: PromConfig{
 					WAL:      "wal-eeee",
 					Endpoint: config.DefaultPrometheusEndpoint,
+					MaxPointAge: DurationConfig{
+						25 * time.Hour,
+					},
 				},
 				Admin: AdminConfig{
 					ListenAddress: config.DefaultAdminListenAddress,
@@ -296,6 +302,7 @@ diagnostics:
 prometheus:
   wal: /volume/wal
   endpoint: http://127.0.0.1:19090/
+  max_point_age: 72h
 
 startup_delay: 30s
 
@@ -349,6 +356,9 @@ static_metadata:
 				Prometheus: PromConfig{
 					WAL:      "/volume/wal",
 					Endpoint: "http://127.0.0.1:19090/",
+					MaxPointAge: DurationConfig{
+						72 * time.Hour,
+					},
 				},
 				OpenTelemetry: OTelConfig{
 					MetricsPrefix: "prefix.",

--- a/example_test.go
+++ b/example_test.go
@@ -39,7 +39,8 @@ func Example() {
 	//   },
 	//   "prometheus": {
 	//     "endpoint": "http://127.0.0.1:19090",
-	//     "wal": "/volume/wal"
+	//     "wal": "/volume/wal",
+	//     "max_point_age": "72h0m0s"
 	//   },
 	//   "opentelemetry": {
 	//     "metrics_prefix": "prefix.",

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -94,7 +94,7 @@ func TestReader_Progress(t *testing.T) {
 		"job1/inst1/metric1": &metadata.Entry{Metric: "metric1", MetricType: textparse.MetricTypeGauge, Help: "help"},
 	}
 
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "")
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", 0)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -151,7 +151,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "")
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", 0)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -27,6 +27,9 @@ prometheus:
   # Location of the write-ahead-log directory.
   wal: /volume/wal
 
+  # Skip points older than this
+  max_point_age: 72h
+
 # OpenTelemetry settings:
 opentelemetry:
   # Metrics prefix is prepended to all exported metric names:


### PR DESCRIPTION
New command-line flag `--prometheus.max-point-age=<duration>` configures the sidecar to skip points older than a configured maximum age. The default is 25h.