### PR TITLE
Enable gRPC verbose logging with --log.verbose setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Add `--log.verbose` setting and enable verbose gRPC logging. (#50)
+
 ### Changed
 
 ## [0.3.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.3.0) - 2020-12-08

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -74,6 +74,15 @@ func main() {
 		os.Exit(2)
 	}
 
+	vlevel := cfg.LogConfig.Verbose
+	if cfg.LogConfig.Level == "debug" {
+		vlevel++
+	}
+
+	if vlevel > 0 {
+		telemetry.SetVerboseLevel(vlevel)
+	}
+
 	var plc promlog.Config
 	plc.Level = &promlog.AllowedLevel{}
 	plc.Format = &promlog.AllowedFormat{}

--- a/config/config.go
+++ b/config/config.go
@@ -71,8 +71,9 @@ type OTLPConfig struct {
 }
 
 type LogConfig struct {
-	Level  string `json:"level"`
-	Format string `json:"format"`
+	Level   string `json:"level"`
+	Format  string `json:"format"`
+	Verbose int    `json:"verbose"`
 }
 
 type PromConfig struct {
@@ -132,8 +133,9 @@ func DefaultMainConfig() MainConfig {
 			Attributes: map[string]string{},
 		},
 		LogConfig: LogConfig{
-			Level:  "info",
-			Format: "logfmt",
+			Level:   "info",
+			Format:  "logfmt",
+			Verbose: 0,
 		},
 		StartupDelay: DurationConfig{
 			DefaultStartupDelay,
@@ -202,6 +204,8 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag(promlogflag.LevelFlagName, promlogflag.LevelFlagHelp).StringVar(&cfg.LogConfig.Level)
 	a.Flag(promlogflag.FormatFlagName, promlogflag.FormatFlagHelp).StringVar(&cfg.LogConfig.Format)
+	a.Flag("log.verbose", "Verbose level: 0 = off, 1 = some, 2 = more; add 1 if log.level is 'debug'").
+		IntVar(&cfg.LogConfig.Verbose)
 
 	_, err := a.Parse(args[1:])
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -204,7 +204,7 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag(promlogflag.LevelFlagName, promlogflag.LevelFlagHelp).StringVar(&cfg.LogConfig.Level)
 	a.Flag(promlogflag.FormatFlagName, promlogflag.FormatFlagHelp).StringVar(&cfg.LogConfig.Format)
-	a.Flag("log.verbose", "Verbose level: 0 = off, 1 = some, 2 = more; add 1 if log.level is 'debug'").
+	a.Flag("log.verbose", "Verbose logging level: 0 = off, 1 = some, 2 = more; 1 is automatically added when log.level is 'debug'; impacts logging from the gRPC library in particular").
 		IntVar(&cfg.LogConfig.Verbose)
 
 	_, err := a.Parse(args[1:])

--- a/example_test.go
+++ b/example_test.go
@@ -88,8 +88,9 @@ func Example() {
 	//     }
 	//   ],
 	//   "log_config": {
-	//     "level": "warn",
-	//     "format": "json"
+	//     "level": "debug",
+	//     "format": "json",
+	//     "verbose": 1
 	//   }
 	// }
 }

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -91,5 +91,6 @@ startup_delay: 30s
 
 # Control the format and level of console-logging output:
 log_config:
-  level: warn
+  level: debug
   format: json
+  verbose: 1

--- a/telemetry/static.go
+++ b/telemetry/static.go
@@ -113,8 +113,6 @@ func newForGRPC(l log.Logger) forGRPC {
 	}
 }
 
-// Info and Verbose logs are no-ops.
-
 func (l forGRPC) Info(args ...interface{}) {
 	l.loggers[0].Log("message", fmt.Sprint(args...))
 }


### PR DESCRIPTION
Adds a --log.verbose setting that controls grpc-go logging, in particular.
Since there is already one level of "debug" logging, debug logging automatically raises the verbose level by 1.