### PR TITLE
Add configurable Export timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Add `--destination.timeout` and `--diagnostics.timeout` values to set gRPC timeout for
+  primary and diagnostic OTLP Export() calls. (#51)
+
 ## [0.3.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.3.0) - 2020-12-08
 
 - Change several metric names to use `.` instead of `_` for 

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -141,12 +141,17 @@ func main() {
 			cfg.Diagnostics.Attributes[serviceNameKey] = "opentelemetry-prometheus-sidecar"
 		}
 
+		// TODO: Configure metric reporting interval, trace batching interval,
+		// currently there is no such setting.
+
 		defer telemetry.ConfigureOpentelemetry(
 			telemetry.WithExporterEndpoint(hostport),
 			telemetry.WithExporterInsecure(endpoint.Scheme == "http"),
 			telemetry.WithLogger(log.With(logger, "component", "telemetry")),
 			telemetry.WithHeaders(cfg.Diagnostics.Headers),
 			telemetry.WithResourceAttributes(cfg.Diagnostics.Attributes),
+			telemetry.WithExportTimeout(cfg.Diagnostics.Timeout.Duration),
+			telemetry.WithMetricReportingPeriod(config.DefaultReportingPeriod),
 		).Shutdown()
 	}
 
@@ -204,7 +209,7 @@ func main() {
 	var scf otlp.StorageClientFactory = &otlpClientFactory{
 		logger:   log.With(logger, "component", "storage"),
 		url:      outputURL,
-		timeout:  10 * time.Second,
+		timeout:  cfg.Destination.Timeout.Duration,
 		security: cfg.Security,
 		headers:  grpcMetadata.New(cfg.Destination.Headers),
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ const (
 	DefaultAdminListenAddress = "0.0.0.0:9091"
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"
 	DefaultMaxPointAge        = time.Hour * 25
+	DefaultExportTimeout      = time.Second * 60
+	DefaultReportingPeriod    = time.Second * 30
 
 	briefDescription = `
 The OpenTelemetry Prometheus sidecar runs alongside the
@@ -68,6 +70,7 @@ type OTLPConfig struct {
 	Endpoint   string            `json:"endpoint"`
 	Headers    map[string]string `json:"headers"`
 	Attributes map[string]string `json:"attributes"`
+	Timeout    DurationConfig    `json:"timeout"`
 }
 
 type LogConfig struct {
@@ -126,10 +129,12 @@ func DefaultMainConfig() MainConfig {
 		Destination: OTLPConfig{
 			Headers:    map[string]string{},
 			Attributes: map[string]string{},
+			Timeout:    DurationConfig{DefaultExportTimeout},
 		},
 		Diagnostics: OTLPConfig{
 			Headers:    map[string]string{},
 			Attributes: map[string]string{},
+			Timeout:    DurationConfig{DefaultExportTimeout},
 		},
 		LogConfig: LogConfig{
 			Level:  "info",
@@ -168,6 +173,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 		a.Flag(lowerPrefix+".header", upperPrefix+" headers used for OTLP requests (e.g., MyHeader=Value1). May be repeated.").
 			StringMapVar(&op.Headers)
+
+		a.Flag(lowerPrefix+".timeout", upperPrefix+" timeout used for OTLP Export() requests").
+			DurationVar(&op.Timeout.Duration)
 	}
 
 	makeOTLPFlags("destination", &cfg.Destination)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -141,6 +141,7 @@ destination:
   headers:
     e: f
     g: h
+  timeout: 14s
 
 prometheus:
   wal: wal-eeee
@@ -170,10 +171,16 @@ startup_delay: 1333s
 						"e": "f",
 						"g": "h",
 					},
+					Timeout: DurationConfig{
+						14 * time.Second,
+					},
 				},
 				Diagnostics: OTLPConfig{
 					Headers:    map[string]string{},
 					Attributes: map[string]string{},
+					Timeout: DurationConfig{
+						60 * time.Second,
+					},
 				},
 				LogConfig: LogConfig{
 					Level:  "info",
@@ -259,6 +266,9 @@ log_config:
 						"e": "f",
 						"g": "h",
 					},
+					Timeout: DurationConfig{
+						60 * time.Second,
+					},
 				},
 				Filters: []string{
 					`one{two="three"}`,
@@ -270,6 +280,9 @@ log_config:
 					Endpoint:   "https://look.here",
 					Headers:    map[string]string{},
 					Attributes: map[string]string{},
+					Timeout: DurationConfig{
+						60 * time.Second,
+					},
 				},
 				LogConfig: LogConfig{
 					Level:  "warning",
@@ -291,6 +304,7 @@ destination:
 
   attributes:
     service.name: demo
+  timeout: 10m
 
 diagnostics:
   endpoint: https://diagnose.me
@@ -298,6 +312,7 @@ diagnostics:
     A: B
   attributes:
     C: D
+  timeout: 1h40m
 
 prometheus:
   wal: /volume/wal
@@ -372,6 +387,9 @@ static_metadata:
 					Headers: map[string]string{
 						"Lightstep-Access-Token": "aabbccdd...wwxxyyzz",
 					},
+					Timeout: DurationConfig{
+						600 * time.Second,
+					},
 				},
 				Diagnostics: OTLPConfig{
 					Endpoint: "https://diagnose.me",
@@ -380,6 +398,9 @@ static_metadata:
 					},
 					Attributes: map[string]string{
 						"C": "D",
+					},
+					Timeout: DurationConfig{
+						6000 * time.Second,
 					},
 				},
 				LogConfig: LogConfig{

--- a/example_test.go
+++ b/example_test.go
@@ -35,7 +35,8 @@ func Example() {
 	//     "attributes": {
 	//       "environment": "public",
 	//       "service.name": "demo"
-	//     }
+	//     },
+	//     "timeout": "2m0s"
 	//   },
 	//   "prometheus": {
 	//     "endpoint": "http://127.0.0.1:19090",
@@ -62,7 +63,8 @@ func Example() {
 	//     },
 	//     "attributes": {
 	//       "environment": "internal"
-	//     }
+	//     },
+	//     "timeout": "1m0s"
 	//   },
 	//   "startup_delay": "30s",
 	//   "filters": [

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -19,6 +19,8 @@ destination:
     service.name: demo
     environment: public
 
+  timeout: 2m
+
 # Promehteus configuration:
 prometheus:
   # The primary HTTP endpoint:

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -138,18 +137,6 @@ func TestValidConfig1(t *testing.T) {
 func filterDebugLogs() (*testLogger, log.Logger) {
 	tl := &testLogger{}
 	return tl, level.NewFilter(tl, level.AllowInfo())
-}
-
-func TestInvalidMetricsPushIntervalConfig(t *testing.T) {
-	logger := &testLogger{}
-	lsOtel := ConfigureOpentelemetry(
-		WithLogger(logger),
-		WithExporterEndpoint("127.0.0.1:4000"),
-		WithMetricReportingPeriod(-time.Second),
-	)
-	defer lsOtel.Shutdown()
-
-	logger.requireContains(t, "invalid metric reporting period")
 }
 
 func TestDebugEnabled(t *testing.T) {


### PR DESCRIPTION
The export timeout was hard-coded at 10s. This makes it configurable and sets the default to 60s.
Although the OTel-Go Metrics SDK has an export timeout configuration, the OTel-Go Trace SDK does not. TODOs were filed along with OTel-Go issue https://github.com/open-telemetry/opentelemetry-go/issues/1386.