### PR TITLE
Update to gRPC 1.34; remove manual resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20201014170642-d1624618ad65 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
-	google.golang.org/grpc v1.33.2
+	google.golang.org/grpc v1.34.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/d4l3k/messagediff.v1 v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/containerd v1.3.4 h1:3o0smo5SKY7H6AJCmJhsnCjR2/V2T8VmiHt7seN2/kI=
@@ -199,6 +200,7 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1221,6 +1223,8 @@ google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
+google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
+google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	grpcMetadata "google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
 )
 
@@ -58,7 +57,6 @@ type Client struct {
 	logger           log.Logger
 	url              *url.URL
 	timeout          time.Duration
-	resolver         *manual.Resolver
 	rootCertificates []string
 	headers          grpcMetadata.MD
 
@@ -70,7 +68,6 @@ type ClientConfig struct {
 	Logger           log.Logger
 	URL              *url.URL
 	Timeout          time.Duration
-	Resolver         *manual.Resolver
 	RootCertificates []string
 	Headers          grpcMetadata.MD
 }
@@ -85,7 +82,6 @@ func NewClient(conf *ClientConfig) *Client {
 		logger:           logger,
 		url:              conf.URL,
 		timeout:          conf.Timeout,
-		resolver:         conf.Resolver,
 		rootCertificates: conf.RootCertificates,
 		headers:          conf.Headers,
 	}
@@ -144,9 +140,6 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 	address := c.url.Hostname()
 	if len(c.url.Port()) > 0 {
 		address = net.JoinHostPort(address, c.url.Port())
-	}
-	if c.resolver != nil {
-		address = c.resolver.Scheme() + ":///" + address
 	}
 	conn, err := grpc.DialContext(ctx, address, dopts...)
 	c.conn = conn

--- a/otlp/client_test.go
+++ b/otlp/client_test.go
@@ -14,22 +14,16 @@
 package otlp
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"net/url"
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	metricsService "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/collector/metrics/v1"
 	metric_pb "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/resolver/manual"
 )
-
-// var longErrMessage = strings.Repeat("[error message]", 10)
 
 func newLocalListener() net.Listener {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -48,7 +42,7 @@ func TestStoreErrorHandlingOnTimeout(t *testing.T) {
 	go grpcServer.Serve(listener)
 	defer grpcServer.Stop()
 
-	serverURL, err := url.Parse("https://" + listener.Addr().String() + "?auth=false")
+	serverURL, err := url.Parse("https://" + listener.Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,111 +61,6 @@ func TestStoreErrorHandlingOnTimeout(t *testing.T) {
 	}
 }
 
-// func TestStoreErrorHandling(t *testing.T) {
-// 	tests := []struct {
-// 		status      *status.Status
-// 		pointCount  map[codes.Code]int64
-// 		recoverable bool
-// 	}{
-// 		{
-// 			status: nil,
-// 			// The successful point count comes from the number of time series in the request when the RPC completely succeeds.
-// 			pointCount: map[codes.Code]int64{codes.OK: 1},
-// 		},
-// 		{
-// 			status: mustStatusWithDetails(status.New(codes.InvalidArgument, longErrMessage),
-// 				&monitoring.CreateTimeSeriesSummary{
-// 					TotalPointCount:   5,
-// 					SuccessPointCount: 2,
-// 					Errors: []*monitoring.CreateTimeSeriesSummary_Error{
-// 						&monitoring.CreateTimeSeriesSummary_Error{
-// 							Status:     status.New(codes.InvalidArgument, "bad points").Proto(),
-// 							PointCount: 2,
-// 						},
-// 						&monitoring.CreateTimeSeriesSummary_Error{
-// 							Status:     status.New(codes.NotFound, "unknown metric").Proto(),
-// 							PointCount: 1,
-// 						},
-// 					},
-// 				}),
-// 			pointCount:  map[codes.Code]int64{codes.OK: 2, codes.InvalidArgument: 2, codes.NotFound: 1},
-// 			recoverable: false,
-// 		},
-// 		{
-// 			status:      status.New(codes.Unavailable, longErrMessage),
-// 			recoverable: true,
-// 		},
-// 		{
-// 			status:      status.New(codes.DeadlineExceeded, longErrMessage),
-// 			recoverable: true,
-// 		},
-// 	}
-
-// 	for i, test := range tests {
-// 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-// 			metricReader := metricexport.NewReader()
-// 			metrics := opencensus.NewTestExporter(metricReader)
-// 			metrics.ReadAndExport()
-// 			pointCountBase := make(map[codes.Code]int64)
-// 			for code := range test.pointCount {
-// 				pointCountBase[code] = getCounter(t, metrics, PointCount.Name(), newPointCountMetricKey(code))
-// 			}
-
-// 			listener := newLocalListener()
-// 			grpcServer := grpc.NewServer()
-// 			metricsService.RegisterMetricsServiceServer(grpcServer, &metricServiceServer{test.status})
-// 			go grpcServer.Serve(listener)
-// 			defer grpcServer.Stop()
-
-// 			serverURL, err := url.Parse("https://" + listener.Addr().String() + "?auth=false")
-// 			if err != nil {
-// 				t.Fatal(err)
-// 			}
-
-// 			logBuffer := &bytes.Buffer{}
-// 			c := NewClient(&ClientConfig{
-// 				URL:     serverURL,
-// 				Timeout: time.Second,
-// 				Logger:  log.NewLogfmtLogger(logBuffer),
-// 			})
-
-// 			err = c.Store(&metricsService.ExportMetricsServiceRequest{
-// 				ResourceMetrics: []*metric_pb.ResourceMetrics{
-// 					&metric_pb.ResourceMetrics{},
-// 				},
-// 			})
-// 			if test.status != nil {
-// 				rerr, recoverable := err.(recoverableError)
-// 				if recoverable != test.recoverable {
-// 					if test.recoverable {
-// 						t.Errorf("expected recoverableError in error %v", err)
-// 					} else {
-// 						t.Errorf("unexpected recoverableError in error %v", err)
-// 					}
-// 				}
-// 				if recoverable {
-// 					err = rerr.error
-// 				}
-// 				status := status.Convert(err)
-// 				if status.Code() != test.status.Code() || status.Message() != test.status.Message() {
-// 					t.Errorf("expected status '%v', got '%v'", test.status.Err(), status.Err())
-// 				}
-// 			}
-
-// 			metrics.ReadAndExport()
-// 			for code, expectedCount := range test.pointCount {
-// 				pointCount := getCounter(t, metrics, PointCount.Name(), newPointCountMetricKey(code)) - pointCountBase[code]
-// 				if expectedCount != pointCount {
-// 					t.Errorf("pointCount has unexpected value: got %v, expected %v", pointCount, expectedCount)
-// 				}
-// 			}
-// 			if logBuffer.Len() > 0 {
-// 				t.Log("logging output:\n", logBuffer.String())
-// 			}
-// 		})
-// 	}
-// }
-
 func TestEmptyRequest(t *testing.T) {
 	serverURL, err := url.Parse("http://localhost:12345")
 	if err != nil {
@@ -185,98 +74,3 @@ func TestEmptyRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
-func TestResolver(t *testing.T) {
-	tests := []struct {
-		host            string
-		expectedAddress string
-	}{
-		{
-			"opentelemetry.invalid",
-			"opentelemetry.invalid",
-		},
-		{
-			"[2001:db8::]",
-			"2001:db8::",
-		},
-	}
-	for _, test := range tests {
-		grpcServer := grpc.NewServer()
-		listener := newLocalListener()
-		metricsService.RegisterMetricsServiceServer(grpcServer, &metricServiceServer{nil})
-		go grpcServer.Serve(listener)
-		defer grpcServer.Stop()
-
-		logBuffer := &bytes.Buffer{}
-		defer func() {
-			if logBuffer.Len() > 0 {
-				t.Log(logBuffer.String())
-			}
-		}()
-		logger := log.NewLogfmtLogger(logBuffer)
-
-		// Without ?auth=false, the test fails with context deadline exceeded.
-		serverURL, err := url.Parse(fmt.Sprintf("http://%s?auth=false", test.host))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		res, _ := manual.GenerateAndRegisterManualResolver()
-		res.InitialState(resolver.State{
-			Addresses: []resolver.Address{
-				{Addr: listener.Addr().String()},
-			}})
-
-		c := NewClient(&ClientConfig{
-			URL:      serverURL,
-			Timeout:  time.Second,
-			Resolver: res,
-			Logger:   logger,
-		})
-
-		err = c.Store(&metricsService.ExportMetricsServiceRequest{
-			ResourceMetrics: []*metric_pb.ResourceMetrics{
-				&metric_pb.ResourceMetrics{},
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		requestedTarget := c.conn.Target()
-		expectedTarget := fmt.Sprintf("%s:///%s",
-			c.resolver.Scheme(), test.expectedAddress)
-		if requestedTarget != expectedTarget {
-			t.Errorf("ERROR: got target as %s, want %s",
-				requestedTarget, expectedTarget)
-		}
-	}
-}
-
-// func newPointCountMetricKey(c codes.Code) map[string]string {
-// 	return map[string]string{
-// 		StatusTag.Name(): fmt.Sprint(uint32(c)),
-// 	}
-// }
-
-// func getCounter(t *testing.T, metrics *opencensus.TestExporter, metricName string, metricKey map[string]string) int64 {
-// 	p, ok := metrics.GetPoint(metricName, metricKey)
-// 	if !ok {
-// 		// This is OK before the metric has been first recorded.
-// 		return 0
-// 	}
-// 	switch v := p.Value.(type) {
-// 	case int64:
-// 		return v
-// 	default:
-// 		t.Fatalf("expected a counter for metric %v, got %v", metricName, p)
-// 	}
-// 	return -1
-// }
-
-// func mustStatusWithDetails(s *status.Status, details ...proto.Message) *status.Status {
-// 	if s, err := s.WithDetails(details...); err != nil {
-// 		panic(err)
-// 	} else {
-// 		return s
-// 	}
-// }


### PR DESCRIPTION
The gRPC resolver had changed signatures and hasn't been used or tested.
This functionality supports better load balancer policies and can be reintroduced later.
This removes some dead test code that was too Stackdriver specific to update.

Issue about restoring these tests: https://github.com/lightstep/opentelemetry-prometheus-sidecar/issues/53.