### PR TITLE
Do not expose port 9091 in Dockerfile (port not used)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,4 @@ LABEL maintainer "Lightstep Engineering <engineering@lightstep.com>"
 
 COPY opentelemetry-prometheus-sidecar /bin/opentelemetry-prometheus-sidecar
 
-EXPOSE 9091
-
 ENTRYPOINT [ "/bin/opentelemetry-prometheus-sidecar" ]

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 	@echo ">> running goveralls"
 	$(GOVERALLS) -coverprofile=coverage.out -service=travis-ci -repotoken "${COVERALLS_TOKEN}"
 
-build: promu
+build: promu vendor
 	@echo ">> building binaries"
 	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)
 


### PR DESCRIPTION
This adds a missing `make` rule used in building Docker images as well.