### PR TITLE
Reduce gRPC logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+
+- gRPC logging is enabled only when --log.level=debug or --log.verbose > 0. (#59)
+
 ## [0.5.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.5.0) - 2020-12-12
 
 ### Changed

--- a/telemetry/static.go
+++ b/telemetry/static.go
@@ -113,20 +113,33 @@ func newForGRPC(l log.Logger) forGRPC {
 	}
 }
 
+// The Info methods are disabled until some degree of verbosity is
+// set; the main() function adds 1 to verbosity so that
+// --log.level=debug enables gRPC logging in this way.
+
 func (l forGRPC) Info(args ...interface{}) {
+	if VerboseLevel() <= 0 {
+		return
+	}
 	l.loggers[0].Log("message", fmt.Sprint(args...))
 }
 
 func (l forGRPC) Infoln(args ...interface{}) {
+	if VerboseLevel() <= 0 {
+		return
+	}
 	l.loggers[0].Log("message", fmt.Sprintln(args...))
 }
 
 func (l forGRPC) Infof(format string, args ...interface{}) {
+	if VerboseLevel() <= 0 {
+		return
+	}
 	l.loggers[0].Log("message", fmt.Sprintf(format, args...))
 }
 
 func (l forGRPC) V(level int) bool {
-	return level <= verboseLevel.Load().(int)
+	return level <= VerboseLevel()
 }
 
 func (l forGRPC) Warning(args ...interface{}) {


### PR DESCRIPTION
This disables gRPC INFO logging when --log.level is not debug OR --log.verbose is not 0.
The standard logging for the default round-robin DNS resolver is very noisy in the 0.5.0 release configuration.