### PR TITLE
Improve startup diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Improve startup diagnostics, add selftest step to check for a healthy endpoint. (#62)
+
 ### Changed
 
 ## [0.7.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.7.0) - 2020-12-24

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -445,6 +445,8 @@ func parseFilters(logger log.Logger, filters []string) ([][]*labels.Matcher, err
 func selfTest(logger log.Logger, scf otlp.StorageClientFactory, timeout time.Duration) error {
 	client := scf.New()
 
+	level.Info(logger).Log("msg", "starting selftest")
+
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -458,5 +460,6 @@ func selfTest(logger log.Logger, scf otlp.StorageClientFactory, timeout time.Dur
 		return fmt.Errorf("error closing test client: %w", err)
 	}
 
+	level.Info(logger).Log("msg", "selftest was successful")
 	return nil
 }

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -55,7 +55,6 @@ func TestStartupInterrupt(t *testing.T) {
 		os.Args[0],
 		append(e2eTestMainCommonFlags,
 			"--prometheus.wal=testdata/wal",
-			"--destination.timeout=30s",
 		)...)
 
 	cmd.Env = append(os.Environ(), "RUN_MAIN=1")

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -184,5 +184,5 @@ func TestStartupUnhealthyEndpoint(t *testing.T) {
 	t.Logf("stderr: %v\n", berr.String())
 
 	require.Contains(t, berr.String(), "selftest failed, not starting")
-	require.Contains(t, berr.String(), "selftest failed, not starting")
+	require.Contains(t, berr.String(), "selftest recoverable error, still trying")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	DefaultStartupDelay       = time.Minute
-	DefaultStartupTimeout     = time.Minute
+	DefaultStartupTimeout     = 5 * time.Minute
 	DefaultWALDirectory       = "data/wal"
 	DefaultAdminListenAddress = "0.0.0.0:9091"
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	DefaultStartupDelay       = time.Minute
+	DefaultStartupTimeout     = time.Minute
 	DefaultWALDirectory       = "data/wal"
 	DefaultAdminListenAddress = "0.0.0.0:9091"
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"
@@ -105,6 +106,7 @@ type MainConfig struct {
 	Security       SecurityConfig         `json:"security"`
 	Diagnostics    OTLPConfig             `json:"diagnostics"`
 	StartupDelay   DurationConfig         `json:"startup_delay"`
+	StartupTimeout DurationConfig         `json:"startup_timeout"`
 	Filters        []string               `json:"filters"`
 	MetricRenames  []MetricRenamesConfig  `json:"metric_renames"`
 	StaticMetadata []StaticMetadataConfig `json:"static_metadata"`
@@ -144,6 +146,9 @@ func DefaultMainConfig() MainConfig {
 		},
 		StartupDelay: DurationConfig{
 			DefaultStartupDelay,
+		},
+		StartupTimeout: DurationConfig{
+			DefaultStartupTimeout,
 		},
 	}
 }
@@ -209,6 +214,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag("startup.delay", "Delay at startup to allow Prometheus its initial scrape. Default: "+DefaultStartupDelay.String()).
 		DurationVar(&cfg.StartupDelay.Duration)
+
+	a.Flag("startup.timeout", "Timeout at startup to allow the endpoint to become available. Default: "+DefaultStartupTimeout.String()).
+		DurationVar(&cfg.StartupTimeout.Duration)
 
 	a.Flag(promlogflag.LevelFlagName, promlogflag.LevelFlagHelp).StringVar(&cfg.LogConfig.Level)
 	a.Flag(promlogflag.FormatFlagName, promlogflag.FormatFlagHelp).StringVar(&cfg.LogConfig.Format)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -147,6 +147,7 @@ prometheus:
   wal: wal-eeee
 
 startup_delay: 1333s
+startup_timeout: 1777s
 
 `,
 			nil,
@@ -188,6 +189,9 @@ startup_delay: 1333s
 				},
 				StartupDelay: DurationConfig{
 					1333 * time.Second,
+				},
+				StartupTimeout: DurationConfig{
+					1777 * time.Second,
 				},
 			},
 			"",
@@ -237,6 +241,7 @@ log_config:
 `,
 			[]string{
 				"--startup.delay=1333s",
+				"--startup.timeout=1777s",
 				"--destination.attribute", "c=d",
 				"--destination.header", "g=h",
 				"--prometheus.wal", "wal-eeee",
@@ -291,6 +296,9 @@ log_config:
 				StartupDelay: DurationConfig{
 					1333 * time.Second,
 				},
+				StartupTimeout: DurationConfig{
+					1777 * time.Second,
+				},
 			},
 			"",
 		},
@@ -320,6 +328,7 @@ prometheus:
   max_point_age: 72h
 
 startup_delay: 30s
+startup_timeout: 33s
 
 log_config:
   level: warn
@@ -367,6 +376,9 @@ static_metadata:
 				},
 				StartupDelay: DurationConfig{
 					30 * time.Second,
+				},
+				StartupTimeout: DurationConfig{
+					33 * time.Second,
 				},
 				Prometheus: PromConfig{
 					WAL:      "/volume/wal",

--- a/example_test.go
+++ b/example_test.go
@@ -1,98 +1,99 @@
 package sidecar
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"log"
+        "encoding/json"
+        "fmt"
+        "io/ioutil"
+        "log"
 
-	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
+        "github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 )
 
 func Example() {
-	cfg, _, _, err := config.Configure([]string{
-		"program",
-		"--config-file=./sidecar.example.yaml",
-	}, ioutil.ReadFile)
-	if err != nil {
-		log.Fatal(err)
-	}
+        cfg, _, _, err := config.Configure([]string{
+                "program",
+                "--config-file=./sidecar.example.yaml",
+        }, ioutil.ReadFile)
+        if err != nil {
+                log.Fatal(err)
+        }
 
-	data, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		log.Fatal(err)
-	}
+        data, err := json.MarshalIndent(cfg, "", "  ")
+        if err != nil {
+                log.Fatal(err)
+        }
 
-	fmt.Println(string(data))
+        fmt.Println(string(data))
 
-	// Output:
-	// {
-	//   "destination": {
-	//     "endpoint": "https://otlp.io:443",
-	//     "headers": {
-	//       "Access-Token": "aabbccdd...wwxxyyzz"
-	//     },
-	//     "attributes": {
-	//       "environment": "public",
-	//       "service.name": "demo"
-	//     },
-	//     "timeout": "2m0s"
-	//   },
-	//   "prometheus": {
-	//     "endpoint": "http://127.0.0.1:19090",
-	//     "wal": "/volume/wal",
-	//     "max_point_age": "72h0m0s"
-	//   },
-	//   "opentelemetry": {
-	//     "metrics_prefix": "prefix.",
-	//     "use_meta_labels": true
-	//   },
-	//   "admin": {
-	//     "listen_address": "0.0.0.0:10000"
-	//   },
-	//   "security": {
-	//     "root_certificates": [
-	//       "/certs/root1.crt",
-	//       "/certs/root2.crt"
-	//     ]
-	//   },
-	//   "diagnostics": {
-	//     "endpoint": "https://otlp.io:443",
-	//     "headers": {
-	//       "Access-Token": "wwxxyyzz...aabbccdd"
-	//     },
-	//     "attributes": {
-	//       "environment": "internal"
-	//     },
-	//     "timeout": "1m0s"
-	//   },
-	//   "startup_delay": "30s",
-	//   "filters": [
-	//     "metric{label=value}",
-	//     "other{l1=v1,l2=v2}"
-	//   ],
-	//   "metric_renames": [
-	//     {
-	//       "from": "old_metric",
-	//       "to": "new_metric"
-	//     },
-	//     {
-	//       "from": "mistake",
-	//       "to": "correct"
-	//     }
-	//   ],
-	//   "static_metadata": [
-	//     {
-	//       "metric": "network_bps",
-	//       "type": "counter",
-	//       "value_type": "int64",
-	//       "help": "Number of bits transferred by this process."
-	//     }
-	//   ],
-	//   "log_config": {
-	//     "level": "debug",
-	//     "format": "json",
-	//     "verbose": 1
-	//   }
-	// }
+        // Output:
+        // {
+        //   "destination": {
+        //     "endpoint": "https://otlp.io:443",
+        //     "headers": {
+        //       "Access-Token": "aabbccdd...wwxxyyzz"
+        //     },
+        //     "attributes": {
+        //       "environment": "public",
+        //       "service.name": "demo"
+        //     },
+        //     "timeout": "2m0s"
+        //   },
+        //   "prometheus": {
+        //     "endpoint": "http://127.0.0.1:19090",
+        //     "wal": "/volume/wal",
+        //     "max_point_age": "72h0m0s"
+        //   },
+        //   "opentelemetry": {
+        //     "metrics_prefix": "prefix.",
+        //     "use_meta_labels": true
+        //   },
+        //   "admin": {
+        //     "listen_address": "0.0.0.0:10000"
+        //   },
+        //   "security": {
+        //     "root_certificates": [
+        //       "/certs/root1.crt",
+        //       "/certs/root2.crt"
+        //     ]
+        //   },
+        //   "diagnostics": {
+        //     "endpoint": "https://otlp.io:443",
+        //     "headers": {
+        //       "Access-Token": "wwxxyyzz...aabbccdd"
+        //     },
+        //     "attributes": {
+        //       "environment": "internal"
+        //     },
+        //     "timeout": "1m0s"
+        //   },
+        //   "startup_delay": "30s",
+        //   "startup_timeout": "5m0s",
+        //   "filters": [
+        //     "metric{label=value}",
+        //     "other{l1=v1,l2=v2}"
+        //   ],
+        //   "metric_renames": [
+        //     {
+        //       "from": "old_metric",
+        //       "to": "new_metric"
+        //     },
+        //     {
+        //       "from": "mistake",
+        //       "to": "correct"
+        //     }
+        //   ],
+        //   "static_metadata": [
+        //     {
+        //       "metric": "network_bps",
+        //       "type": "counter",
+        //       "value_type": "int64",
+        //       "help": "Number of bits transferred by this process."
+        //     }
+        //   ],
+        //   "log_config": {
+        //     "level": "debug",
+        //     "format": "json",
+        //     "verbose": 1
+        //   }
+        // }
 }

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -157,8 +157,6 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 
 // Selftest sends an empty request the endpoint.
 func (c *Client) Selftest(ctx context.Context) error {
-	level.Debug(c.logger).Log("msg", "starting selftest")
-
 	// Loop until the context is canceled, allowing for retryable failures.
 	for {
 		conn, err := c.getConnection(ctx)
@@ -169,7 +167,6 @@ func (c *Client) Selftest(ctx context.Context) error {
 
 			_, err = service.Export(c.grpcMetadata(ctx), empty)
 			if err == nil {
-				level.Debug(c.logger).Log("msg", "selftest was successful")
 				return nil
 			}
 		}

--- a/otlp/client_test.go
+++ b/otlp/client_test.go
@@ -22,6 +22,7 @@ import (
 
 	metricsService "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/collector/metrics/v1"
 	metric_pb "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -56,9 +57,7 @@ func TestStoreErrorHandlingOnTimeout(t *testing.T) {
 			&metric_pb.ResourceMetrics{},
 		},
 	})
-	if _, recoverable := err.(recoverableError); !recoverable {
-		t.Errorf("expected recoverableError in error %v", err)
-	}
+	require.True(t, isRecoverable(err), "expected recoverableError in error %v", err)
 }
 
 func TestEmptyRequest(t *testing.T) {

--- a/otlp/queue_manager_test.go
+++ b/otlp/queue_manager_test.go
@@ -176,6 +176,10 @@ func (t *TestStorageClient) New() StorageClient {
 	return t
 }
 
+func (t *TestStorageClient) Selftest() error {
+	return nil
+}
+
 func (c *TestStorageClient) Name() string {
 	return "teststorageclient"
 }
@@ -411,6 +415,10 @@ func (c *TestBlockingStorageClient) unlock() {
 
 func (t *TestBlockingStorageClient) New() StorageClient {
 	return t
+}
+
+func (t *TestBlockingStorageClient) Selftest() error {
+	return nil
 }
 
 func (c *TestBlockingStorageClient) Name() string {

--- a/otlp/queue_manager_test.go
+++ b/otlp/queue_manager_test.go
@@ -35,6 +35,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestStorageClient simulates a storage that can store samples and compares it
@@ -176,7 +179,7 @@ func (t *TestStorageClient) New() StorageClient {
 	return t
 }
 
-func (t *TestStorageClient) Selftest() error {
+func (t *TestStorageClient) Selftest(context.Context) error {
 	return nil
 }
 
@@ -417,7 +420,7 @@ func (t *TestBlockingStorageClient) New() StorageClient {
 	return t
 }
 
-func (t *TestBlockingStorageClient) Selftest() error {
+func (t *TestBlockingStorageClient) Selftest(context.Context) error {
 	return nil
 }
 
@@ -437,6 +440,14 @@ func (t *QueueManager) queueLen() int {
 		queueLength += len(shard.queue)
 	}
 	return queueLength
+}
+
+func TestRecoverable(t *testing.T) {
+	require.True(t, isRecoverable(context.Canceled))
+	require.True(t, isRecoverable(context.DeadlineExceeded))
+	require.True(t, isRecoverable(status.Error(codes.Unavailable, "try again later")))
+	require.False(t, isRecoverable(status.Error(codes.PermissionDenied, "sorry")))
+	require.False(t, isRecoverable(fmt.Errorf("no idea what this is")))
 }
 
 func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -91,6 +91,10 @@ static_metadata:
 # write-ahead-log entries after startup:
 startup_delay: 30s
 
+# Startup timeout determines how long to wait for the endpoint to
+# become available once before entering the initial run state.
+startup_timeout: 300s
+
 # Control the format and level of console-logging output:
 log_config:
   level: debug

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -276,8 +276,6 @@ func ConfigureOpentelemetry(opts ...Option) *Telemetry {
 
 	var startFuncs []func(context.Context) error
 
-	staticSetup(tel.config.logger)
-
 	for _, setup := range []setupFunc{tel.config.setupTracing, tel.config.setupMetrics} {
 		start, shutdown, err := setup()
 		if err != nil {


### PR DESCRIPTION
Adds a selftest feature, where the sidecar will test its destination endpoint before entering the initial run state.
The selftest is governed by a `--startup.timeout` flag, defaulting to 5 minutes. If the destination endpoint is not healthy in 5 minutes, the sidecar will exit. Adds testing for this.

Refactors some of the static logging code that was not working correctly, ensuring consistent timestamps, initialization, and style. Fix the handling of "context canceled" by improving how recoverable errors are tested.