### PR TITLE
removing WithBalancerName option

### DIFF
--- a/otlp/client.go
+++ b/otlp/client.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
 	grpcMetadata "google.golang.org/grpc/metadata"
 )
@@ -134,7 +133,6 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 		"timeout", c.timeout)
 
 	dopts := []grpc.DialOption{
-		grpc.WithBalancerName(roundrobin.Name),
 		grpc.WithBlock(), // Wait for the connection to be established before using it.
 		grpc.WithUserAgent(userAgent),
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),


### PR DESCRIPTION
This option is being deprecated in favour of WithDefaultServiceConfig. See
https://godoc.org/google.golang.org/grpc#WithBalancerName