### PR TITLE
Autoconfigure diagnostics to the primary destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Enable self-diagnostics using the OTel-Go SDK, using the primary destination
+  by default if none is configured.  Disable this behavior with --disable-diagnostics. (#72)
+
 ## [0.10.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.10.0) - 2021-01-21
 
 - Fixes bug in WAL-tailer `openSegment()` method. (#71)

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -142,16 +142,23 @@ func main() {
 
 	telemetry.StaticSetup(logger)
 
-	if cfg.Diagnostics.Endpoint != "" {
-		endpoint, _ := url.Parse(cfg.Diagnostics.Endpoint)
+	// Determine the diagnostics configuration.
+	diagConfig := cfg.Diagnostics
+
+	if diagConfig.Endpoint == "" && !cfg.DisableDiagnostics {
+		diagConfig = cfg.Destination
+	}
+
+	if diagConfig.Endpoint != "" {
+		endpoint, _ := url.Parse(diagConfig.Endpoint)
 		hostport := endpoint.Hostname()
 		if len(endpoint.Port()) > 0 {
 			hostport = net.JoinHostPort(hostport, endpoint.Port())
 		}
 		// Set a service.name resource if none is set.
 		const serviceNameKey = "service.name"
-		if _, ok := cfg.Diagnostics.Attributes[serviceNameKey]; !ok {
-			cfg.Diagnostics.Attributes[serviceNameKey] = "opentelemetry-prometheus-sidecar"
+		if _, ok := diagConfig.Attributes[serviceNameKey]; !ok {
+			diagConfig.Attributes[serviceNameKey] = "opentelemetry-prometheus-sidecar"
 		}
 
 		// TODO: Configure metric reporting interval, trace batching interval,
@@ -161,9 +168,9 @@ func main() {
 			telemetry.WithLogger(logger),
 			telemetry.WithExporterEndpoint(hostport),
 			telemetry.WithExporterInsecure(endpoint.Scheme == "http"),
-			telemetry.WithHeaders(cfg.Diagnostics.Headers),
-			telemetry.WithResourceAttributes(cfg.Diagnostics.Attributes),
-			telemetry.WithExportTimeout(cfg.Diagnostics.Timeout.Duration),
+			telemetry.WithHeaders(diagConfig.Headers),
+			telemetry.WithResourceAttributes(diagConfig.Attributes),
+			telemetry.WithExportTimeout(diagConfig.Timeout.Duration),
 			telemetry.WithMetricReportingPeriod(telemetry.DefaultReportingPeriod),
 		).Shutdown(context.Background())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,8 @@ type MainConfig struct {
 	StaticMetadata []StaticMetadataConfig `json:"static_metadata"`
 	LogConfig      LogConfig              `json:"log_config"`
 
+	DisableDiagnostics bool `json:"disable_diagnostics"`
+
 	// This field cannot be parsed inside a configuration file,
 	// only can be set by command-line flag.:
 	ConfigFilename string `json:"-" yaml:"-"`
@@ -221,6 +223,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 	a.Flag(promlogflag.FormatFlagName, promlogflag.FormatFlagHelp).StringVar(&cfg.LogConfig.Format)
 	a.Flag("log.verbose", "Verbose logging level: 0 = off, 1 = some, 2 = more; 1 is automatically added when log.level is 'debug'; impacts logging from the gRPC library in particular").
 		IntVar(&cfg.LogConfig.Verbose)
+
+	a.Flag("disable-diagnostics", "Disable diagnostics by default; if unset, diagnostics will be auto-configured to the primary destination").
+		BoolVar(&cfg.DisableDiagnostics)
 
 	_, err := a.Parse(args[1:])
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -148,7 +148,6 @@ prometheus:
 
 startup_delay: 1333s
 startup_timeout: 1777s
-
 `,
 			nil,
 			MainConfig{
@@ -247,6 +246,7 @@ log_config:
 				"--prometheus.wal", "wal-eeee",
 				"--log.level=warning",
 				"--diagnostics.endpoint", "https://look.here",
+				"--disable-diagnostics",
 				`--filter=l1{l2="v3"}`,
 				"--filter", `l4{l5="v6"}`,
 			},
@@ -289,6 +289,7 @@ log_config:
 						60 * time.Second,
 					},
 				},
+				DisableDiagnostics: true,
 				LogConfig: LogConfig{
 					Level:  "warning",
 					Format: "json",

--- a/example_test.go
+++ b/example_test.go
@@ -95,6 +95,6 @@ func Example() {
         //     "format": "json",
         //     "verbose": 1
         //   },
-	//   "disable_diagnostics": false
+        //   "disable_diagnostics": false
         // }
 }

--- a/example_test.go
+++ b/example_test.go
@@ -94,6 +94,7 @@ func Example() {
         //     "level": "debug",
         //     "format": "json",
         //     "verbose": 1
-        //   }
+        //   },
+	//   "disable_diagnostics": false
         // }
 }

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -55,13 +55,18 @@ security:
   - /certs/root2.crt
 
 # Diagnostics parameters, where the sidecar will send its own diagnostic
-# data.  This is structurally the same as destination, above.
+# data.  This is structurally the same as destination, above.  If this is
+# not configured and disable_diagnostics is also not set, this section
+# will be auto-configured to match the primary destination.
 diagnostics:
   endpoint: https://otlp.io:443
   headers:
     Access-Token: wwxxyyzz...aabbccdd
   attributes:
     environment: internal
+
+# Set this to prevent auto-configuring diagnostics.
+disable_diagnostics: false
 
 # Filters expressed as Prometheus series expressions.  If any of these
 # are configured, at least one must match for the timeseries be

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/version"
 	hostMetrics "go.opentelemetry.io/contrib/instrumentation/host"
 	runtimeMetrics "go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/contrib/propagators/b3"
@@ -42,6 +43,19 @@ import (
 const (
 	DefaultExportTimeout   = time.Second * 60
 	DefaultReportingPeriod = time.Second * 30
+
+	TelemetryReportingAgentKey = "telemetry-reporting-agent"
+)
+
+var (
+	TelemetryReportingAgentMainValue = fmt.Sprint(
+		"opentelemetry-prometheus-sidecar/",
+		version.Version,
+	)
+	TelemetryReportingAgentSelfValue = fmt.Sprint(
+		"opentelemetry-prometheus-sidecar-self/",
+		version.Version,
+	)
 )
 
 type (
@@ -200,10 +214,16 @@ func newExporter(endpoint string, insecure bool, headers map[string]string) *otl
 	if insecure {
 		secureOption = otlp.WithInsecure()
 	}
+	copyHeaders := map[string]string{
+		TelemetryReportingAgentKey: TelemetryReportingAgentSelfValue,
+	}
+	for k, v := range headers {
+		copyHeaders[k] = v
+	}
 	return otlp.NewUnstartedExporter(
 		secureOption,
 		otlp.WithAddress(endpoint),
-		otlp.WithHeaders(headers),
+		otlp.WithHeaders(copyHeaders),
 	)
 }
 


### PR DESCRIPTION
This ensures that the sidecar will report diagnostics by default.