### PR TITLE
Downcase headers for http2 correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Auto-downcase headers for http2 compliance. (#73)
+
 ## [0.10.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.10.0) - 2021-01-21
 
 - Fixes bug in WAL-tailer `openSegment()` method. (#71)

--- a/config/config.go
+++ b/config/config.go
@@ -256,18 +256,18 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 		}
 	}
 
-	if err := sanitizeValues("destination attribute", cfg.Destination.Attributes); err != nil {
+	if err := sanitizeValues("destination attribute", false, cfg.Destination.Attributes); err != nil {
 		return MainConfig{}, nil, nil, err
 	}
-	if err := sanitizeValues("destination header", cfg.Destination.Headers); err != nil {
+	if err := sanitizeValues("destination header", true, cfg.Destination.Headers); err != nil {
 		return MainConfig{}, nil, nil, err
 	}
 
 	if cfg.Diagnostics.Endpoint != "" {
-		if err := sanitizeValues("diagnostics attribute", cfg.Diagnostics.Attributes); err != nil {
+		if err := sanitizeValues("diagnostics attribute", false, cfg.Diagnostics.Attributes); err != nil {
 			return MainConfig{}, nil, nil, err
 		}
-		if err := sanitizeValues("diagnostics header", cfg.Diagnostics.Headers); err != nil {
+		if err := sanitizeValues("diagnostics header", true, cfg.Diagnostics.Headers); err != nil {
 			return MainConfig{}, nil, nil, err
 		}
 	}
@@ -289,9 +289,12 @@ func sanitize(val string) string {
 	return val
 }
 
-func sanitizeValues(kind string, values map[string]string) error {
+func sanitizeValues(kind string, downcaseKeys bool, values map[string]string) error {
 	for origKey, value := range values {
 		key := sanitize(origKey)
+		if downcaseKeys {
+			key = strings.ToLower(key)
+		}
 		if key == "" {
 			return fmt.Errorf("empty %s key", kind)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -137,10 +137,10 @@ destination:
   endpoint: http://womp.womp
   attributes:
     a: b
-    c: d
+    C: d
   headers:
     e: f
-    g: h
+    G: h
   timeout: 14s
 
 prometheus:
@@ -166,7 +166,7 @@ startup_timeout: 1777s
 					Endpoint: "http://womp.womp",
 					Attributes: map[string]string{
 						"a": "b",
-						"c": "d",
+						"C": "d",
 					},
 					Headers: map[string]string{
 						"e": "f",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -397,7 +397,7 @@ static_metadata:
 						"service.name": "demo",
 					},
 					Headers: map[string]string{
-						"Lightstep-Access-Token": "aabbccdd...wwxxyyzz",
+						"lightstep-access-token": "aabbccdd...wwxxyyzz",
 					},
 					Timeout: DurationConfig{
 						600 * time.Second,
@@ -406,7 +406,7 @@ static_metadata:
 				Diagnostics: OTLPConfig{
 					Endpoint: "https://diagnose.me",
 					Headers: map[string]string{
-						"A": "B",
+						"a": "B",
 					},
 					Attributes: map[string]string{
 						"C": "D",

--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,7 @@ func Example() {
         //   "destination": {
         //     "endpoint": "https://otlp.io:443",
         //     "headers": {
-        //       "Access-Token": "aabbccdd...wwxxyyzz"
+        //       "access-token": "aabbccdd...wwxxyyzz"
         //     },
         //     "attributes": {
         //       "environment": "public",
@@ -59,7 +59,7 @@ func Example() {
         //   "diagnostics": {
         //     "endpoint": "https://otlp.io:443",
         //     "headers": {
-        //       "Access-Token": "wwxxyyzz...aabbccdd"
+        //       "access-token": "wwxxyyzz...aabbccdd"
         //     },
         //     "attributes": {
         //       "environment": "internal"


### PR DESCRIPTION
http/2 specifies that headers must be downcased. Indeed, this is one reason we've seen PROTOCOL_ERRORs. 
Go's gRPC and http2 client/servers do not print much information about these conditions, so correcting it in the configuration parser.