### PR TITLE
Introduce Health and Ready endpoints, Supervisor process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   by default if none is configured.  Disable this behavior with --disable-diagnostics. (#72)
 - Auto-downcase headers for http2 compliance. (#73)
 - Ensures the sidecar will exit non-zero on errors. (#74)
-- Adds a supervisor. (#75)
+- Adds a /-/ready endpoint, where readiness implies:
+  - Prometheus is ready
+  - Can write status file
+  - Export empty request succeeds. (#75)
+- Adds a /-/health endpoint, always returns OK. (#75)
+- Adds a supervisor:
+  - Performs periodic healthcheck
+  - Runs main() in a sub-process, tees stdout and stderr
+  - Records recent logs & healthcheck status in a span. (#75)
+- Disable spans in the sidecar, replace w/ 2 Float64ValueRecorders. (#75)
+
 
 ## [0.10.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.10.0) - 2021-01-21
 

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 // Ports used here:
-// 19000: Prometheus
 // 19001: OTLP service
 // 19002: Scrape target
+// 19093: Prometheus
 
 type (
 	testServer struct {
@@ -50,6 +50,7 @@ var (
 	e2eTestMainCommonFlags = []string{
 		"--security.root-certificate=testdata/certs/root_ca.crt",
 		"--destination.endpoint=https://127.0.0.1:19001",
+		"--prometheus.endpoint=http://0.0.0.0:19093",
 		"--destination.header",
 		fmt.Sprint(e2eTestHeaderName, "=", e2eTestHeaderValue),
 		"--disable-supervisor",
@@ -57,7 +58,7 @@ var (
 		"--admin.port=9093",
 	}
 
-	e2eReadyURL = "http://127.0.0.1:9093/-/ready"
+	e2eReadyURL = "http://0.0.0.0:9093/-/ready"
 )
 
 const (
@@ -101,6 +102,7 @@ func TestE2E(t *testing.T) {
 	defer pipeWrite.Close()
 
 	go func() {
+		// TODO: Replace this with /-/ready check using code elsewhere in this repo.
 		defer pipeRead.Close()
 		for {
 			// This passes output to Stderr but signals
@@ -152,18 +154,16 @@ func TestE2E(t *testing.T) {
 		dataDir,
 		"--config.file",
 		cfgPath,
-		"--web.listen-address=0.0.0.0:19000",
+		"--web.listen-address=0.0.0.0:19093",
 	)
 	promCmd.Stderr = pipeWrite
 	promCmd.Stdout = os.Stdout
 	if err := promCmd.Start(); err != nil {
 		log.Fatal(err)
 	}
-	go func() {
-		log.Printf("Waiting for command to finish...")
-		err := promCmd.Wait()
-		log.Printf("Command finished with error: %v", err)
-	}()
+	defer promCmd.Wait()
+	defer promCmd.Process.Kill()
+
 	// Wait for Prometheus to be ready:
 	select {
 	case <-ready:
@@ -179,10 +179,10 @@ func TestE2E(t *testing.T) {
 		os.Args[0],
 		append(e2eTestMainCommonFlags,
 			"--prometheus.wal", path.Join(dataDir, "wal"),
-			"--prometheus.endpoint=http://127.0.0.1:19000",
 			"--destination.attribute=service.name=Service",
 			"--log.level=debug",
-			"--startup.delay=1s")...,
+			"--startup.delay=1s",
+		)...,
 	)
 	sideCmd.Env = append(os.Environ(), "RUN_MAIN=1")
 	sideCmd.Stderr = os.Stderr
@@ -190,6 +190,8 @@ func TestE2E(t *testing.T) {
 	if err := sideCmd.Start(); err != nil {
 		log.Fatal(err)
 	}
+	defer sideCmd.Wait()
+	defer sideCmd.Process.Kill()
 
 	// Start scrape target
 	go func() {
@@ -252,6 +254,8 @@ func TestE2E(t *testing.T) {
 			val = dp.DoubleGauge.DataPoints[0].Value
 		case *metrics.Metric_DoubleSum:
 			val = dp.DoubleSum.DataPoints[0].Value
+		default:
+			t.Error("Unexpected", result.InstrumentationLibraryMetrics[0].Metrics[0])
 		}
 
 		rvals := map[string]string{}
@@ -364,7 +368,7 @@ func (s *testServer) Stop() {
 func newTestServer(t *testing.T) *testServer {
 	return &testServer{
 		t:      t,
-		stops:  make(chan func(), 2), // 2 = max number of stop functions registered
+		stops:  make(chan func(), 3), // 3 = max number of stop functions registered
 		result: make(chan *metrics.ResourceMetrics, e2eTestScrapes),
 	}
 }

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -56,6 +56,8 @@ var (
 		"--disable-diagnostics",
 		"--admin.port=9093",
 	}
+
+	e2eReadyURL = "http://127.0.0.1:9093/-/ready"
 )
 
 const (

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -54,6 +54,7 @@ var (
 		fmt.Sprint(e2eTestHeaderName, "=", e2eTestHeaderValue),
 		"--disable-supervisor",
 		"--disable-diagnostics",
+		"--admin.port=9093",
 	}
 )
 

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -141,6 +141,9 @@ func TestE2E(t *testing.T) {
 
 	ts := newTestServer(t)
 
+	// start gRPC service
+	go runMetricsService(ts)
+
 	// Run prometheus
 	promCmd := exec.CommandContext(
 		ctx,
@@ -178,6 +181,7 @@ func TestE2E(t *testing.T) {
 			"--prometheus.wal", path.Join(dataDir, "wal"),
 			"--prometheus.endpoint=http://127.0.0.1:19000",
 			"--destination.attribute=service.name=Service",
+			"--log.level=debug",
 			"--startup.delay=1s")...,
 	)
 	sideCmd.Env = append(os.Environ(), "RUN_MAIN=1")
@@ -214,9 +218,6 @@ func TestE2E(t *testing.T) {
 		}
 		_ = s.ListenAndServe()
 	}()
-
-	// start gRPC service
-	go runMetricsService(ts)
 
 	// Gather results
 	var results []*metrics.ResourceMetrics
@@ -308,7 +309,7 @@ func runMetricsService(ts *testServer) {
 		log.Fatal("failed to append client certs")
 	}
 
-	listener, err := net.Listen("tcp", "0.0.0.0:19001")
+	listener, err := net.Listen("tcp", "127.0.0.1:19001")
 	if err != nil {
 		log.Fatalf("failed to listen: %s", err)
 	}

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -52,6 +52,8 @@ var (
 		"--destination.endpoint=https://127.0.0.1:19001",
 		"--destination.header",
 		fmt.Sprint(e2eTestHeaderName, "=", e2eTestHeaderValue),
+		"--disable-supervisor",
+		"--disable-diagnostics",
 	}
 )
 

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -104,42 +104,6 @@ func main() {
 		level.Debug(logger).Log("config", string(data))
 	}
 
-	// We avoided using the kingpin support for URL flags because
-	// it leads to special cases merging configs and because URL
-	// parsing succeeds in cases w/o a scheme, needs to be
-	// validated anyway.
-	type namedURL struct {
-		name       string
-		value      string
-		allowEmpty bool
-	}
-	for _, pair := range []namedURL{
-		{"destination.endpoint", cfg.Destination.Endpoint, false},
-		{"diagnostics.endpoint", cfg.Diagnostics.Endpoint, true},
-		{"prometheus.endpoint", cfg.Prometheus.Endpoint, false},
-	} {
-		if pair.allowEmpty && pair.value == "" {
-			continue
-		}
-		if pair.value == "" {
-			level.Error(logger).Log("msg", "endpoint must be set", "name", pair.name)
-			os.Exit(2)
-		}
-		url, err := url.Parse(pair.value)
-		if err != nil {
-			level.Error(logger).Log("msg", "invalid endpoint", "name", pair.name, "endpoint", pair.value, "error", err)
-			os.Exit(2)
-		}
-
-		switch url.Scheme {
-		case "http", "https":
-			// Good!
-		default:
-			level.Error(logger).Log("msg", "endpoints must use http or https", "name", pair.name, "endpoint", pair.value)
-			os.Exit(2)
-		}
-	}
-
 	telemetry.StaticSetup(logger)
 
 	if cfg.Diagnostics.Endpoint != "" {

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -376,6 +376,13 @@ func selfTest(ctx context.Context, promURL *url.URL, scf otlp.StorageClientFacto
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	// These tests are performed sequentially, to keep the logs simple.
+	// Note waitForPrometheus has no unrecoverable error conditions, so
+	// loops until success or the context is canceled.
+	if !waitForPrometheus(ctx, logger, promURL) {
+		return fmt.Errorf("Prometheus is not ready")
+	}
+
 	// Outbound connection test.
 	{
 		if err := client.Selftest(ctx); err != nil {
@@ -386,13 +393,6 @@ func selfTest(ctx context.Context, promURL *url.URL, scf otlp.StorageClientFacto
 		if err := client.Close(); err != nil {
 			return fmt.Errorf("error closing test client: %w", err)
 		}
-	}
-
-	// These tests are performed sequentially, to keep the logs simple.
-	// Note waitForPrometheus has no unrecoverable error conditions, so
-	// loops until success or the context is canceled.
-	if !waitForPrometheus(ctx, logger, promURL) {
-		return fmt.Errorf("Prometheus is not ready")
 	}
 
 	level.Debug(logger).Log("msg", "selftest was successful")

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -92,18 +92,6 @@ func main() {
 	plc.Format.Set(cfg.LogConfig.Format)
 	logger := promlog.New(&plc)
 
-	level.Info(logger).Log(
-		"msg", "Starting OpenTelemetry Prometheus sidecar",
-		"version", version.Info(),
-		"build_context", version.BuildContext(),
-		"host_details", Uname(),
-		"fd_limits", FdLimits(),
-	)
-
-	if data, err := json.Marshal(cfg); err == nil {
-		level.Debug(logger).Log("config", string(data))
-	}
-
 	telemetry.StaticSetup(logger)
 
 	if cfg.Diagnostics.Endpoint != "" {
@@ -130,6 +118,18 @@ func main() {
 			telemetry.WithExportTimeout(cfg.Diagnostics.Timeout.Duration),
 			telemetry.WithMetricReportingPeriod(telemetry.DefaultReportingPeriod),
 		).Shutdown(context.Background())
+	}
+
+	level.Info(logger).Log(
+		"msg", "Starting OpenTelemetry Prometheus sidecar",
+		"version", version.Info(),
+		"build_context", version.BuildContext(),
+		"host_details", Uname(),
+		"fd_limits", FdLimits(),
+	)
+
+	if data, err := json.Marshal(cfg); err == nil {
+		level.Debug(logger).Log("config", string(data))
 	}
 
 	// We instantiate a context here since the tailer is used by two other components.

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -293,7 +293,7 @@ func Main() bool {
 	}
 
 	// SIGTERM causes graceful shutdown.
-	level.Info(logger).Log("msg", "shutting down")
+	level.Info(logger).Log("msg", "sidecar process exiting")
 	return true
 }
 

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -131,13 +131,16 @@ func Main() bool {
 			svcName = "opentelemetry-prometheus-sidecar"
 		}
 
+		agentName := config.AgentSecondaryValue
 		if isSupervisor {
 			// Disable metrics in the supervisor
 			metricsHostport = ""
 			svcName = svcName + "-supervisor"
+			agentName = config.AgentSupervisorValue
 		}
 
 		diagConfig.Attributes[serviceNameKey] = svcName
+		diagConfig.Headers[config.AgentKey] = agentName
 
 		// TODO: Configure metric reporting interval, trace batching interval,
 		// currently there is no such setting.
@@ -150,7 +153,7 @@ func Main() bool {
 			telemetry.WithHeaders(diagConfig.Headers),
 			telemetry.WithResourceAttributes(diagConfig.Attributes),
 			telemetry.WithExportTimeout(diagConfig.Timeout.Duration),
-			telemetry.WithMetricReportingPeriod(telemetry.DefaultReportingPeriod),
+			telemetry.WithMetricReportingPeriod(config.DefaultReportingPeriod),
 		).Shutdown(context.Background())
 	}
 
@@ -171,6 +174,8 @@ func Main() bool {
 
 		return supervisor.Start(os.Args, logger)
 	}
+
+	cfg.Destination.Headers[config.AgentKey] = config.AgentPrimeValue
 
 	if !cfg.DisableSupervisor {
 		level.Info(logger).Log("msg", "Running under supervisor")

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -219,7 +219,7 @@ func Main() bool {
 		server := newAdminServer(healthChecker, cfg.Admin, logger)
 
 		go func() {
-			level.Info(logger).Log("msg", "admin server started")
+			level.Debug(logger).Log("msg", "starting admin server")
 			<-ctx.Done()
 			if err := server.Shutdown(context.Background()); err != nil {
 				level.Error(logger).Log("msg", "admin server shutdown", "err", err)
@@ -387,7 +387,7 @@ func parseFilters(logger log.Logger, filters []string) ([][]*labels.Matcher, err
 func selfTest(ctx context.Context, promURL *url.URL, scf otlp.StorageClientFactory, timeout time.Duration, logger log.Logger) error {
 	client := scf.New()
 
-	level.Info(logger).Log("msg", "starting selftest")
+	level.Debug(logger).Log("msg", "starting selftest")
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -411,7 +411,7 @@ func selfTest(ctx context.Context, promURL *url.URL, scf otlp.StorageClientFacto
 		return fmt.Errorf("Prometheus is not ready")
 	}
 
-	level.Info(logger).Log("msg", "selftest was successful")
+	level.Debug(logger).Log("msg", "selftest was successful")
 	return nil
 }
 
@@ -447,7 +447,7 @@ func logStartup(cfg config.MainConfig, logger log.Logger) {
 	}
 
 	if !cfg.DisableSupervisor {
-		level.Info(logger).Log("msg", "running under supervisor")
+		level.Debug(logger).Log("msg", "running under supervisor")
 	}
 }
 

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -79,7 +79,7 @@ Loop:
 	// This loop sleeps allows least 10 seconds to pass.
 	for x := 0; x < 10; x++ {
 		// error=nil means the sidecar has started so can send the interrupt signal and wait for the grace shutdown.
-		if _, err := http.Get("http://localhost:9091/metrics"); err == nil {
+		if _, err := http.Get(e2eReadyURL); err == nil {
 			startedOk = true
 			cmd.Process.Signal(os.Interrupt)
 			select {
@@ -114,6 +114,12 @@ Loop:
 	// the test, we should see some gRPC warnings the connection up
 	// until --startup.timeout takes effect.
 	require.Contains(t, berr.String(), "connect: connection refused")
+
+	// The process should have been interrupted.
+	require.Contains(t, berr.String(), "received SIGTERM, exiting")
+
+	// The selftest should have finished, since we waited for ready.
+	require.Contains(t, berr.String(), "selftest was successful")
 }
 
 func TestMainExitOnFailure(t *testing.T) {

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -119,7 +119,7 @@ Loop:
 	require.Contains(t, berr.String(), "received SIGTERM, exiting")
 
 	// The selftest should have finished, since we waited for ready.
-	require.Contains(t, berr.String(), "outbound connection test was successful")
+	require.Contains(t, berr.String(), "selftest was successful")
 }
 
 func TestMainExitOnFailure(t *testing.T) {

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -78,8 +78,8 @@ func TestStartupInterrupt(t *testing.T) {
 Loop:
 	// This loop sleeps allows least 10 seconds to pass.
 	for x := 0; x < 10; x++ {
-		// error=nil means the sidecar has started so can send the interrupt signal and wait for the grace shutdown.
-		if _, err := http.Get(e2eReadyURL); err == nil {
+		// Waits for the sidecar's /-/ready handler
+		if resp, err := http.Get(e2eReadyURL); err == nil && resp.StatusCode/100 == 2 {
 			startedOk = true
 			cmd.Process.Signal(os.Interrupt)
 			select {
@@ -119,7 +119,7 @@ Loop:
 	require.Contains(t, berr.String(), "received SIGTERM, exiting")
 
 	// The selftest should have finished, since we waited for ready.
-	require.Contains(t, berr.String(), "selftest was successful")
+	require.Contains(t, berr.String(), "outbound connection test was successful")
 }
 
 func TestMainExitOnFailure(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,9 @@ const (
 	DefaultStartupTimeout     = time.Minute * 5
 	DefaultSupervisorPeriod   = time.Minute
 
+	DefaultSupervisorBufferSize  = 16384
+	DefaultSupervisorLogsHistory = 16
+
 	briefDescription = `
 The OpenTelemetry Prometheus sidecar runs alongside the
 Prometheus (https://prometheus.io/) Server and sends metrics data to

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,8 @@ type MainConfig struct {
 	StaticMetadata []StaticMetadataConfig `json:"static_metadata"`
 	LogConfig      LogConfig              `json:"log_config"`
 
+	DisableSupervisor bool `json:"disable_supervisor"`
+
 	// This field cannot be parsed inside a configuration file,
 	// only can be set by command-line flag.:
 	ConfigFilename string `json:"-" yaml:"-"`
@@ -222,6 +224,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 	a.Flag(promlogflag.FormatFlagName, promlogflag.FormatFlagHelp).StringVar(&cfg.LogConfig.Format)
 	a.Flag("log.verbose", "Verbose logging level: 0 = off, 1 = some, 2 = more; 1 is automatically added when log.level is 'debug'; impacts logging from the gRPC library in particular").
 		IntVar(&cfg.LogConfig.Verbose)
+
+	a.Flag("disable-supervisor", "Disable the supervisor.").
+		BoolVar(&cfg.DisableSupervisor)
 
 	_, err := a.Parse(args[1:])
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/metadata"
-	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/pkg/errors"
 	promlogflag "github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
@@ -33,18 +32,38 @@ import (
 )
 
 const (
-	DefaultStartupDelay       = time.Minute
-	DefaultStartupTimeout     = 5 * time.Minute
-	DefaultWALDirectory       = "data/wal"
 	DefaultAdminListenAddress = "0.0.0.0:9091"
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"
-	DefaultMaxPointAge        = time.Hour * 25
+	DefaultWALDirectory       = "data/wal"
+
+	DefaultExportTimeout   = time.Second * 60
+	DefaultMaxPointAge     = time.Hour * 25
+	DefaultReportingPeriod = time.Second * 30
+	DefaultStartupDelay    = time.Minute
+	DefaultStartupTimeout  = time.Minute * 5
 
 	briefDescription = `
 The OpenTelemetry Prometheus sidecar runs alongside the
 Prometheus (https://prometheus.io/) Server and sends metrics data to
 an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 `
+
+	AgentKey = "telemetry-reporting-agent"
+)
+
+var (
+	AgentPrimeValue = fmt.Sprint(
+		"opentelemetry-prometheus-sidecar-main/",
+		version.Version,
+	)
+	AgentSecondaryValue = fmt.Sprint(
+		"opentelemetry-prometheus-sidecar-telemetry/",
+		version.Version,
+	)
+	AgentSupervisorValue = fmt.Sprint(
+		"opentelemetry-prometheus-sidecar-supervisor/",
+		version.Version,
+	)
 )
 
 type MetricRenamesConfig struct {
@@ -135,12 +154,12 @@ func DefaultMainConfig() MainConfig {
 		Destination: OTLPConfig{
 			Headers:    map[string]string{},
 			Attributes: map[string]string{},
-			Timeout:    DurationConfig{telemetry.DefaultExportTimeout},
+			Timeout:    DurationConfig{DefaultExportTimeout},
 		},
 		Diagnostics: OTLPConfig{
 			Headers:    map[string]string{},
 			Attributes: map[string]string{},
-			Timeout:    DurationConfig{telemetry.DefaultExportTimeout},
+			Timeout:    DurationConfig{DefaultExportTimeout},
 		},
 		LogConfig: LogConfig{
 			Level:   "info",

--- a/config/config.go
+++ b/config/config.go
@@ -37,12 +37,13 @@ const (
 	DefaultPrometheusEndpoint = "http://127.0.0.1:9090/"
 	DefaultWALDirectory       = "data/wal"
 
-	DefaultExportTimeout    = time.Second * 60
-	DefaultMaxPointAge      = time.Hour * 25
-	DefaultReportingPeriod  = time.Second * 30
-	DefaultStartupDelay     = time.Minute
-	DefaultStartupTimeout   = time.Minute * 5
-	DefaultSupervisorPeriod = time.Minute
+	DefaultExportTimeout      = time.Second * 60
+	DefaultHealthCheckTimeout = time.Second * 5
+	DefaultMaxPointAge        = time.Hour * 25
+	DefaultReportingPeriod    = time.Second * 30
+	DefaultStartupDelay       = time.Minute
+	DefaultStartupTimeout     = time.Minute * 5
+	DefaultSupervisorPeriod   = time.Minute
 
 	briefDescription = `
 The OpenTelemetry Prometheus sidecar runs alongside the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,7 +173,8 @@ startup_timeout: 1777s
 					},
 				},
 				Admin: AdminConfig{
-					ListenAddress: config.DefaultAdminListenAddress,
+					ListenIP: config.DefaultAdminListenIP,
+					Port:     config.DefaultAdminPort,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "http://womp.womp",
@@ -273,7 +274,8 @@ log_config:
 					},
 				},
 				Admin: AdminConfig{
-					ListenAddress: config.DefaultAdminListenAddress,
+					ListenIP: config.DefaultAdminListenIP,
+					Port:     config.DefaultAdminPort,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "http://womp.womp",
@@ -350,7 +352,8 @@ log_config:
   format: json
 
 admin:
-  listen_address: 0.0.0.0:10000
+  listen_ip: 0.0.0.0
+  port: 9999
 
 security:
   root_certificates:
@@ -387,7 +390,8 @@ static_metadata:
 					},
 				},
 				Admin: AdminConfig{
-					ListenAddress: "0.0.0.0:10000",
+					ListenIP: config.DefaultAdminListenIP,
+					Port:     9999,
 				},
 				StartupDelay: DurationConfig{
 					30 * time.Second,

--- a/example_test.go
+++ b/example_test.go
@@ -49,7 +49,7 @@ func Example() {
         //   },
         //   "admin": {
         //     "listen_ip": "0.0.0.0",
-	//     "port": 10000
+        //     "port ": 10000
         //   },
         //   "security": {
         //     "root_certificates": [

--- a/example_test.go
+++ b/example_test.go
@@ -49,7 +49,7 @@ func Example() {
         //   },
         //   "admin": {
         //     "listen_ip": "0.0.0.0",
-        //     "port ": 10000
+        //     "port": 10000
         //   },
         //   "security": {
         //     "root_certificates": [

--- a/example_test.go
+++ b/example_test.go
@@ -94,6 +94,7 @@ func Example() {
         //     "level": "debug",
         //     "format": "json",
         //     "verbose": 1
-        //   }
+        //   },
+	//   "disable_supervisor": false
         // }
 }

--- a/example_test.go
+++ b/example_test.go
@@ -48,7 +48,8 @@ func Example() {
         //     "use_meta_labels": true
         //   },
         //   "admin": {
-        //     "listen_address": "0.0.0.0:10000"
+        //     "listen_ip": "0.0.0.0",
+	//     "port": 10000
         //   },
         //   "security": {
         //     "root_certificates": [

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	// see https://github.com/prometheus/prometheus/issues/7663.
 	github.com/prometheus/prometheus v1.8.2-0.20201015110737-0a7fdd3b7696
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e

--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,6 @@ go.opentelemetry.io/contrib v0.15.1 h1:g3ttZ8E4synHwMhgokRIXghcxkeb6+8nBDeEQmKmH
 go.opentelemetry.io/contrib v0.15.1/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.0 h1:fGqsnhhChJGPxapk8EsRgZQgjJs08OERabMxh/G+NPc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.0/go.mod h1:SRpsFskbEQsGDd7X0zGncMOq6ahEVG/tM6+Iy0cAG6g=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.1 h1:21d2IwOio28aojxvD4n2VfnRMFDD5g2HkztyM1+DPdc=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.1/go.mod h1:acxdpDUa3iNwpo9yz4efI+3sukgLNl3/dnjQQSfYYPs=
 go.opentelemetry.io/contrib/instrumentation/host v0.15.0 h1:INR24WmZlfLcUY0X4iqpeZkDYK80E7VvnyLkS79Debg=
 go.opentelemetry.io/contrib/instrumentation/host v0.15.0/go.mod h1:Ujna/u4jWkqftmLY9XcWroJPuzP148N2uBL0UROOmKc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.0 h1:wAs8k+Wy1lLsrOZHUIO/GA3W4GtgjBHj65Yx4cWxuuE=

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type (
+	Checker struct {
+		ready
+	}
+
+	ready struct {
+	}
+
+	Response struct {
+		Status string `json:"status"`
+	}
+)
+
+func NewChecker() *Checker {
+	return &Checker{}
+}
+
+func (c *Checker) Health() http.Handler {
+	// TODO: Real health checking.
+	return &c.ready
+}
+
+func (c *Checker) Ready() http.Handler {
+	// TODO: Real readiness checking.
+	return &c.ready
+}
+
+func (r *ready) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	status := http.StatusOK
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	json.NewEncoder(w).Encode(Response{
+		Status: http.StatusText(status),
+	})
+}

--- a/health/health.go
+++ b/health/health.go
@@ -66,16 +66,18 @@ func (r *ready) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 }
 
 func ok(w http.ResponseWriter, ok bool) {
-	status := http.StatusServiceUnavailable
+	code := http.StatusServiceUnavailable
+	status := "starting"
 
 	if ok {
-		status = http.StatusOK
+		code = http.StatusOK
+		status = "running"
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(status)
+	w.WriteHeader(code)
 
 	_ = json.NewEncoder(w).Encode(Response{
-		Status: http.StatusText(status),
+		Status: status,
 	})
 }

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -167,6 +167,11 @@ func (c *Client) getConnection(ctx context.Context) (_ *grpc.ClientConn, retErr 
 				RootCAs:    certPool,
 			}
 		}
+		level.Debug(c.logger).Log(
+			"msg", "tls configured",
+			"server", c.url.Hostname(),
+			"root_certs", fmt.Sprint(c.rootCertificates),
+		)
 		dopts = append(dopts, grpc.WithTransportCredentials(credentials.NewTLS(&tcfg)))
 	} else {
 		dopts = append(dopts, grpc.WithInsecure())

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	sidecar "github.com/lightstep/opentelemetry-prometheus-sidecar"
 	metricsService "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/collector/metrics/v1"
-	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
@@ -102,18 +101,12 @@ func NewClient(conf *ClientConfig) *Client {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	copyHeaders := map[string][]string{
-		telemetry.TelemetryReportingAgentKey: []string{telemetry.TelemetryReportingAgentMainValue},
-	}
-	for k, v := range conf.Headers {
-		copyHeaders[k] = append(copyHeaders[k], v...)
-	}
 	return &Client{
 		logger:           logger,
 		url:              conf.URL,
 		timeout:          conf.Timeout,
 		rootCertificates: conf.RootCertificates,
-		headers:          copyHeaders,
+		headers:          conf.Headers,
 	}
 }
 

--- a/sidecar.example.yaml
+++ b/sidecar.example.yaml
@@ -44,8 +44,9 @@ opentelemetry:
 
 # Administrative settings:
 admin:
-  # Listen-address of the sidecar's http server (e.g., for healtchecks)
-  listen_address: 0.0.0.0:10000
+  # Listen address of the sidecar's http server (e.g., for healtchecks)
+  listen_ip: 0.0.0.0
+  port: 10000
 
 # Security settings:
 security:

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -56,6 +56,8 @@ func New(cfg Config) *Supervisor {
 	admin := cfg.Admin
 	endpoint := fmt.Sprint("http://", admin.ListenIP, ":", admin.Port, "/-/health")
 	client := &http.Client{
+		// Note: this connection is traced, even though we
+		// know the server side is also not traced.
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 	return &Supervisor{

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/health"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/label"
@@ -90,8 +91,8 @@ func (s *Supervisor) Run(args []string) bool {
 }
 
 func (s *Supervisor) start(args []string) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancelMain := telemetry.ContextWithSIGTERM(s.logger)
+	defer cancelMain()
 
 	cmd := exec.Command(args[0], args[1:]...)
 

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor
+
+import (
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+func Start(args []string) {
+	cmd := exec.Command(args[0], args[1:])
+
+	if err := cmd.Start(); err != nil {
+		return errors.Wrap(err, "supervisor exec")
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return errors.Wrap(err, "supervisor wait")
+	}
+
+	return nil
+}

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackRegexp(t *testing.T) {
+	buffer := make([]byte, 1<<14)
+	stacksz := runtime.Stack(buffer, true)
+	astack := buffer[:stacksz]
+
+	s := New(Config{
+		Logger: telemetry.StaticLogger(),
+	})
+
+	require.True(t, s.isStackdump(astack), "for stack %q", string(astack))
+	require.False(t, s.isStackdump([]byte(`some
+other
+long
+text
+`)))
+}

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -88,11 +88,11 @@ func (c *Cache) Run(ctx context.Context) {
 }
 
 func (c *Cache) refresh(ctx context.Context) error {
-	req, err := http.NewRequest("GET", c.url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", c.url.String(), nil)
 	if err != nil {
 		return err
 	}
-	resp, err := c.client.Do(req.WithContext(ctx))
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/telemetry/cmd/sidecar-telemetry-test/main.go
+++ b/telemetry/cmd/sidecar-telemetry-test/main.go
@@ -59,8 +59,10 @@ func Main() error {
 
 	defer telemetry.ConfigureOpentelemetry(
 		telemetry.WithLogger(logger),
-		telemetry.WithExporterEndpoint(address),
-		telemetry.WithExporterInsecure(insecure),
+		telemetry.WithSpanExporterEndpoint(address),
+		telemetry.WithSpanExporterInsecure(insecure),
+		telemetry.WithMetricsExporterEndpoint(address),
+		telemetry.WithMetricsExporterInsecure(insecure),
 		telemetry.WithHeaders(headers),
 		telemetry.WithResourceAttributes(map[string]string{
 			"service.name": "sidecar-telemetry-test",

--- a/telemetry/static.go
+++ b/telemetry/static.go
@@ -78,6 +78,10 @@ func (dl *deferLogger) Log(kvs ...interface{}) error {
 	return delegate.Log(kvs...)
 }
 
+func StaticLogger() log.Logger {
+	return staticLogger
+}
+
 func init() {
 	verboseLevel.Store(int(0))
 

--- a/telemetry/static.go
+++ b/telemetry/static.go
@@ -16,11 +16,14 @@ package telemetry
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	stdlog "log"
 	"os"
+	"os/signal"
 	"sync"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -93,6 +96,26 @@ func StaticSetup(logger log.Logger) {
 	staticDeferred.lock.Lock()
 	defer staticDeferred.lock.Unlock()
 	staticDeferred.delegate = logger
+}
+
+// ContextWithSIGTERM returns a context that will be cancelled on SIGTERM.
+func ContextWithSIGTERM(logger log.Logger) (context.Context, context.CancelFunc) {
+	ctx, cancelMain := context.WithCancel(context.Background())
+
+	go func() {
+		defer cancelMain()
+
+		term := make(chan os.Signal)
+		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+		select {
+		case <-term:
+			level.Warn(logger).Log("msg", "received SIGTERM, exiting...")
+		case <-ctx.Done():
+			break
+		}
+	}()
+
+	return ctx, cancelMain
 }
 
 type forOTel struct {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -299,9 +299,8 @@ func ConfigureOpentelemetry(opts ...Option) *Telemetry {
 		config: newConfig(opts...),
 	}
 
-	level.Debug(tel.config.logger).Log("msg", "debug logging enabled")
 	s, _ := json.MarshalIndent(tel.config, "", "\t")
-	level.Debug(tel.config.logger).Log("configuration", string(s))
+	level.Debug(tel.config.logger).Log("msg", "telemetry enabled", "cfg", string(s))
 
 	var startFuncs []func(context.Context) error
 

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -112,7 +112,8 @@ func TestTraceEndpointDisabled(t *testing.T) {
 	testEndpointDisabled(
 		t,
 		expectedTracingDisabledMessage,
-		WithExporterEndpoint(""),
+		WithSpanExporterEndpoint(""),
+		WithMetricsExporterEndpoint("https://otlp"),
 	)
 }
 
@@ -120,7 +121,8 @@ func TestMetricEndpointDisabled(t *testing.T) {
 	testEndpointDisabled(
 		t,
 		expectedMetricsDisabledMessage,
-		WithExporterEndpoint(""),
+		WithMetricsExporterEndpoint(""),
+		WithSpansExporterEndpoint("https://otlp"),
 	)
 }
 

--- a/telemetry/timer.go
+++ b/telemetry/timer.go
@@ -1,0 +1,71 @@
+// Copyright Lightstep Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+// Note: Tracing has been disabled here and elsewhere in the main
+// sidecar code.  However, we'd like to use it along with
+// span-to-metrics to measure latency, throughput, and error rate of
+// the outbound connections utilizing the tracing instrumentation.
+// This could be done with an OTel-Go Metrics SDK adatper.  Since this
+// would be more work, the simpler approach taken here uses a
+// ValueRecorder instrument and a simple calling pattern.
+
+import (
+	"context"
+	"time"
+
+	sidecar "github.com/lightstep/opentelemetry-prometheus-sidecar"
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type (
+	Timer metric.Float64ValueRecorder
+
+	Timing struct {
+		ctx     context.Context
+		timer   Timer
+		started time.Time
+	}
+)
+
+func NewTimer(name, desc string) Timer {
+	return Timer(
+		sidecar.OTelMeterMust.NewFloat64ValueRecorder(
+			name,
+			metric.WithDescription(desc),
+			metric.WithUnit("s"),
+		),
+	)
+}
+
+func (t Timer) Start(ctx context.Context) Timing {
+	return Timing{
+		ctx:     ctx,
+		timer:   t,
+		started: time.Now(),
+	}
+}
+
+func (t Timing) Stop(err *error, kvs ...label.KeyValue) {
+	errorval := "false"
+	if err != nil && *err != nil {
+		errorval = "true"
+	}
+
+	kvs = append(kvs, label.String("error", errorval))
+
+	metric.Float64ValueRecorder(t.timer).Record(t.ctx, time.Since(t.started).Seconds(), kvs...)
+}


### PR DESCRIPTION
Adds Ready (`/-/ready`) and Health (`/-/health`) endpoints. 

The Ready endpoint is functional and transitions to readiness following the existing three readiness checks. This required some re-organization of the main() function's run block, which had 5 concurrent parts and now has 3. The SIGTERM handler and Admin HTTP server have moved earlier in the startup, and no longer use the `oklog/run` convenience package, instead using the context/cancellation framework in place (since these 2 parts cannot trigger failure of the sidecar's main function). 

The three existing checks covered by readiness:

1. Is the Prometheus server also /-/ready?
2. Can the sidecar's `wal/opentelemetry_sidecar.json` file be read and written?
3. Can the destination `Export()` be called with an empty request (currently what's called "selftest")?

Note that parts 1 and 2 are presently called _after_ the current "selftest" completes, making the /-/ready check more comprehensive after this PR.

The Health endpoint is a stub for future work, currently always responds 200 with OK status string.

Adds a "Supervisor" mode, on by default, and moves all span-based telemetry into the supervisor. The supervisor fork/execs the subordinate sidecar process with identical configuration to itself, tees and records log lines from stderr, and periodically calls the Ready or Health endpoints to monitor the sidecar process. Currently, the supervisor's monitoring consists of a periodic Span containing the results of the Ready or Health check and a tail of the logs written by the subordinate sidecar.

The subordinate process disables tracing, the supervisor disables metrics.  The two existing sidecar spans are replaced by Float64ValueRecorder instruments, that will output OTLP histogram points for monitoring the sidecar.

The sidecar will record logs in a final span in case of a crashing subordinate sidecar.

(Reviewer notes: the `main()` function had gotten too big, so I moved a bunch of its sections into separate functions for readability. I will annotate `main.go` to assist the reviewers.)