### PR TITLE
Re-use the gRPC connection after failure (revert to SD behavior)

### DIFF
--- a/otlp/client.go
+++ b/otlp/client.go
@@ -171,6 +171,7 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 		address = net.JoinHostPort(address, c.url.Port())
 	}
 	conn, err := grpc.DialContext(ctx, address, dopts...)
+	c.conn = conn
 	if err != nil {
 		level.Debug(c.logger).Log(
 			"msg", "connection status",
@@ -179,13 +180,6 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 		)
 		return nil, err
 	}
-	// Note: Set the connection when there is not an error. The
-	// upstream Stackdriver Prometheus sidecar sets the connection
-	// unconditionally, which is probably also correct, however we
-	// have seen a connection problem in some environments and
-	// will not set the connection after error until those reports
-	// are explained.
-	c.conn = conn
 
 	return conn, err
 }


### PR DESCRIPTION
An earlier release introduced this minor regression from the Stackdriver behavior. Since we later discovered the cause of our connection problems, this reverts that change.