### PR TITLE
Terminate the subordinate sidecar to support graceful shutdown

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ const (
 	DefaultMaxPointAge        = time.Hour * 25
 	DefaultReportingPeriod    = time.Second * 30
 	DefaultStartupDelay       = time.Minute
+	DefaultShutdownDelay      = time.Minute
 	DefaultStartupTimeout     = time.Minute * 5
 	DefaultSupervisorPeriod   = time.Minute
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	// see https://github.com/prometheus/prometheus/issues/7663.
 	github.com/prometheus/prometheus v1.8.2-0.20201015110737-0a7fdd3b7696
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1 // indirect
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20201014170642-d1624618ad65 // indirect


### PR DESCRIPTION
Kubernetes would deliver SIGTERM to the supervisor, not the whole process group. The supervisor is waiting for the subordinate to drain its stderr pipe, therefore with this PR we tell the subordinate to shut down.

Fixes #78. 