### PR TITLE
Use a 2 second maximum backoff for Export()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Use a 2 second maximum backoff when Export() fails (vs 100ms default). (#81)
+
 ## [0.11.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.11.1) - 2021-01-26
 
 - Fix for graceful shutdown. (#79)

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/oklog/run"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/version"
 	promconfig "github.com/prometheus/prometheus/config"
@@ -153,6 +154,8 @@ func Main() bool {
 		level.Error(logger).Log("msg", "tailing WAL failed", "err", err)
 		return false
 	}
+
+	promconfig.DefaultQueueConfig.MaxBackoff = model.Duration(2 * time.Second)
 	promconfig.DefaultQueueConfig.MaxSamplesPerSend = otlp.MaxTimeseriesesPerRequest
 	// We want the queues to have enough buffer to ensure consistent flow with full batches
 	// being available for every new request.

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -63,6 +63,8 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 	tailSamples := samples[1:]
 
 	if math.IsNaN(sample.V) {
+		// Note: This includes stale markers, which are
+		// specific NaN values defined in prometheus/tsdb.
 		return nil, 0, tailSamples, nil
 	}
 


### PR DESCRIPTION
The default was 100ms, which results in a lot of fast-fail requests when the endpoint is not reachable. This just tones it down.