### PR TITLE
Use uint64, not float64, for progress report

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -364,7 +364,7 @@ func (r *Response) MetricLogSummary(name string) (pairs []interface{}) {
 				// The log package strips `=`, replace with `:` instead.
 				"{", strings.Replace(e.Labels, "=", ":", -1), "}",
 			),
-			e.Value)
+			uint64(e.Value))
 	}
 	return
 }


### PR DESCRIPTION
The default logging format (%v) for floating point would lose information after 10^7 bytes.