### PR TITLE
Set service.instance.id for the Destination/Diagnostics Resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Prometheus for readiness and the current segment number during WAL segment
   transitions. (#118)
 - Remove the use_meta_labels parameter. (#125)
+- Automatically set (the same) `service.instance.id` for Destination/Diagnostics
+  Resources. (#127)
 
 ## [0.16.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.16.0) - 2021-02-18
 

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -26,6 +26,8 @@ import (
 	common "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
 	metrics "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
 	traces "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/trace/v1"
+	"go.opentelemetry.io/otel/semconv"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	grpcMetadata "google.golang.org/grpc/metadata"
@@ -284,11 +286,8 @@ func TestE2E(t *testing.T) {
 
 		// At this moment, the labels in static_configs are NOT
 		// passed to the Resource.
-		if diff, equal := messagediff.PrettyDiff(rvals, map[string]string{
-			"service.name": "Service",
-		}); !equal {
-			t.Errorf("unexpected resources:\n%v", diff)
-		}
+		assert.Equal(t, rvals[string(semconv.ServiceNameKey)], "Service")
+		assert.NotEqual(t, rvals[string(semconv.ServiceInstanceIDKey)], "")
 
 		output[name] = append(output[name], val)
 	}

--- a/cmd/stresstest/main.go
+++ b/cmd/stresstest/main.go
@@ -73,6 +73,7 @@ func Main() bool {
 	telem := internal.StartTelemetry(
 		cfg,
 		"stresstest-prometheus-sidecar",
+		"stresstest-prometheus-sidecar-001",
 		false,
 		logger,
 	)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2
 	github.com/google/go-cmp v0.5.4
+	github.com/google/uuid v1.1.2
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0


### PR DESCRIPTION
Sidecars need a unique label to identify their pushed metrics. `service.instance.id` is a suitable choice, although a dedicated label would do. The reason this makes sense for the sidecar's primary destination is that the sidecar is the process responsible for calculating timeseries resets. It is the service instance, in this case, since PRW data otherwise cannot be translated directly into OTLP.
