### PR TITLE
adding option to configure max-timeseries-per-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Flags:
                                  http://127.0.0.1:9090/
       --prometheus.max-point-age=PROMETHEUS.MAX-POINT-AGE  
                                  Skip points older than this, to assist recovery. Default: 25h0m0s
+      --prometheus.max-timeseries-per-request=PROMETHEUS.MAX-TIMESERIES-PER-REQUEST  
+                                 Send at most this number of timeseries per request. Default: 2000
       --admin.port=ADMIN.PORT    Administrative port this process listens on. Default: 9091
       --admin.listen-ip=ADMIN.LISTEN-IP  
                                  Administrative IP address this process listens on. Default: 0.0.0.0

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -196,6 +196,8 @@ func TestE2E(t *testing.T) {
 			"--prometheus.wal", path.Join(dataDir, "wal"),
 			"--destination.attribute=service.name=Service",
 			"--startup.delay=1s",
+			// TODO: check this value is set correctly
+			"--prometheus.max-timeseries-per-request=10",
 		)...,
 	)
 	sideCmd.Env = append(os.Environ(), "RUN_MAIN=1")

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -196,8 +196,6 @@ func TestE2E(t *testing.T) {
 			"--prometheus.wal", path.Join(dataDir, "wal"),
 			"--destination.attribute=service.name=Service",
 			"--startup.delay=1s",
-			// TODO: check this value is set correctly
-			"--prometheus.max-timeseries-per-request=10",
 		)...,
 	)
 	sideCmd.Env = append(os.Environ(), "RUN_MAIN=1")

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -158,6 +158,7 @@ func Main() bool {
 		RootCertificates: cfg.Security.RootCertificates,
 		Headers:          grpcMetadata.New(cfg.Destination.Headers),
 		Compressor:       cfg.Destination.Compression,
+		Prometheus:       cfg.Prometheus,
 	})
 
 	queueManager, err := otlp.NewQueueManager(

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -161,7 +161,7 @@ func Main() bool {
 
 	queueManager, err := otlp.NewQueueManager(
 		log.With(logger, "component", "queue_manager"),
-		config.DefaultQueueConfig(),
+		cfg.QueueConfig(),
 		cfg.Destination.Timeout.Duration,
 		scf,
 		tailer,

--- a/cmd/stresstest/main.go
+++ b/cmd/stresstest/main.go
@@ -92,7 +92,7 @@ func Main() bool {
 
 	queueManager, err := otlp.NewQueueManager(
 		log.With(logger, "component", "queue_manager"),
-		config.DefaultQueueConfig(),
+		cfg.QueueConfig(),
 		cfg.Destination.Timeout.Duration,
 		scf,
 		&fakeTailer{time.Now()},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,6 +173,7 @@ startup_timeout: 1777s
 					MaxPointAge: DurationConfig{
 						25 * time.Hour,
 					},
+					MaxTimeseriesPerRequest: 2000,
 				},
 				Admin: AdminConfig{
 					ListenIP:          config.DefaultAdminListenIP,
@@ -265,6 +266,8 @@ log_config:
 				"--destination.header", "g=h",
 				"--destination.compression", "compression_fmt",
 				"--prometheus.wal", "wal-eeee",
+				"--prometheus.max-point-age", "10h",
+				"--prometheus.max-timeseries-per-request", "5",
 				"--log.level=warning",
 				"--healthcheck.period=17s",
 				"--diagnostics.endpoint", "https://look.here",
@@ -277,8 +280,9 @@ log_config:
 					WAL:      "wal-eeee",
 					Endpoint: config.DefaultPrometheusEndpoint,
 					MaxPointAge: DurationConfig{
-						25 * time.Hour,
+						10 * time.Hour,
 					},
+					MaxTimeseriesPerRequest: 5,
 				},
 				Admin: AdminConfig{
 					ListenIP:          config.DefaultAdminListenIP,
@@ -355,6 +359,7 @@ prometheus:
   wal: /volume/wal
   endpoint: http://127.0.0.1:19090/
   max_point_age: 72h
+  max_timeseries_per_request: 10
 
 startup_delay: 30s
 startup_timeout: 33s
@@ -418,6 +423,7 @@ static_metadata:
 					MaxPointAge: DurationConfig{
 						72 * time.Hour,
 					},
+					MaxTimeseriesPerRequest: 10,
 				},
 				OpenTelemetry: OTelConfig{
 					MetricsPrefix: "prefix.",

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -1,103 +1,104 @@
 package config
 
 import (
-        "encoding/json"
-        "fmt"
-        "io/ioutil"
-        "log"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
 )
 
 func Example() {
-        cfg, _, _, err := Configure([]string{
-                "program",
-                "--config-file=./sidecar.example.yaml",
-        }, ioutil.ReadFile)
-        if err != nil {
-                log.Fatal(err)
-        }
+	cfg, _, _, err := Configure([]string{
+		"program",
+		"--config-file=./sidecar.example.yaml",
+	}, ioutil.ReadFile)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-        data, err := json.MarshalIndent(cfg, "", "  ")
-        if err != nil {
-                log.Fatal(err)
-        }
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-        fmt.Println(string(data))
+	fmt.Println(string(data))
 
-        // Output:
-        // {
-        //   "destination": {
-        //     "endpoint": "https://otlp.io:443",
-        //     "headers": {
-        //       "access-token": "aabbccdd...wwxxyyzz"
-        //     },
-        //     "attributes": {
-        //       "environment": "public",
-        //       "service.name": "demo"
-        //     },
-        //     "timeout": "2m0s",
-        //     "compression": "snappy"
-        //   },
-        //   "prometheus": {
-        //     "endpoint": "http://127.0.0.1:19090",
-        //     "wal": "/volume/wal",
-        //     "max_point_age": "72h0m0s"
-        //   },
-        //   "opentelemetry": {
-        //     "metrics_prefix": "prefix.",
-        //     "use_meta_labels": true
-        //   },
-        //   "admin": {
-        //     "listen_ip": "0.0.0.0",
-        //     "port": 10000,
-        //     "health_check_period": "20s"
-        //   },
-        //   "security": {
-        //     "root_certificates": [
-        //       "/certs/root1.crt",
-        //       "/certs/root2.crt"
-        //     ]
-        //   },
-        //   "diagnostics": {
-        //     "endpoint": "https://otlp.io:443",
-        //     "headers": {
-        //       "access-token": "wwxxyyzz...aabbccdd"
-        //     },
-        //     "attributes": {
-        //       "environment": "internal"
-        //     },
-        //     "timeout": "1m0s",
-        //     "compression": "snappy"
-        //   },
-        //   "startup_delay": "30s",
-        //   "startup_timeout": "5m0s",
-        //   "filters": [
-        //     "metric{label=value}",
-        //     "other{l1=v1,l2=v2}"
-        //   ],
-        //   "metric_renames": [
-        //     {
-        //       "from": "old_metric",
-        //       "to": "new_metric"
-        //     },
-        //     {
-        //       "from": "mistake",
-        //       "to": "correct"
-        //     }
-        //   ],
-        //   "static_metadata": [
-        //     {
-        //       "metric": "network_bps",
-        //       "type": "counter",
-        //       "value_type": "int64",
-        //       "help": "Number of bits transferred by this process."
-        //     }
-        //   ],
-        //   "log_config": {
-        //     "level": "debug",
-        //     "format": "json",
-        //     "verbose": 1
-        //   },
-        //   "disable_supervisor": false,
-        //   "disable_diagnostics": false
-        // }
+	// Output:
+	// {
+	//   "destination": {
+	//     "endpoint": "https://otlp.io:443",
+	//     "headers": {
+	//       "access-token": "aabbccdd...wwxxyyzz"
+	//     },
+	//     "attributes": {
+	//       "environment": "public",
+	//       "service.name": "demo"
+	//     },
+	//     "timeout": "2m0s",
+	//     "compression": "snappy"
+	//   },
+	//   "prometheus": {
+	//     "endpoint": "http://127.0.0.1:19090",
+	//     "wal": "/volume/wal",
+	//     "max_point_age": "72h0m0s",
+	//     "max_timeseries_per_request": 2000
+	//   },
+	//   "opentelemetry": {
+	//     "metrics_prefix": "prefix.",
+	//     "use_meta_labels": true
+	//   },
+	//   "admin": {
+	//     "listen_ip": "0.0.0.0",
+	//     "port": 10000,
+	//     "health_check_period": "20s"
+	//   },
+	//   "security": {
+	//     "root_certificates": [
+	//       "/certs/root1.crt",
+	//       "/certs/root2.crt"
+	//     ]
+	//   },
+	//   "diagnostics": {
+	//     "endpoint": "https://otlp.io:443",
+	//     "headers": {
+	//       "access-token": "wwxxyyzz...aabbccdd"
+	//     },
+	//     "attributes": {
+	//       "environment": "internal"
+	//     },
+	//     "timeout": "1m0s",
+	//     "compression": "snappy"
+	//   },
+	//   "startup_delay": "30s",
+	//   "startup_timeout": "5m0s",
+	//   "filters": [
+	//     "metric{label=value}",
+	//     "other{l1=v1,l2=v2}"
+	//   ],
+	//   "metric_renames": [
+	//     {
+	//       "from": "old_metric",
+	//       "to": "new_metric"
+	//     },
+	//     {
+	//       "from": "mistake",
+	//       "to": "correct"
+	//     }
+	//   ],
+	//   "static_metadata": [
+	//     {
+	//       "metric": "network_bps",
+	//       "type": "counter",
+	//       "value_type": "int64",
+	//       "help": "Number of bits transferred by this process."
+	//     }
+	//   ],
+	//   "log_config": {
+	//     "level": "debug",
+	//     "format": "json",
+	//     "verbose": 1
+	//   },
+	//   "disable_supervisor": false,
+	//   "disable_diagnostics": false
+	// }
 }

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -35,6 +35,9 @@ prometheus:
   # Skip points older than this
   max_point_age: 72h
 
+  # Send at most this number of timeseries per request
+  max_timeseries_per_request: 2000
+
 # OpenTelemetry settings:
 opentelemetry:
   # Metrics prefix is prepended to all exported metric names:

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -247,10 +247,11 @@ func (c *Client) Store(req *metricsService.ExportMetricsServiceRequest) error {
 
 	service := metricsService.NewMetricsServiceClient(conn)
 
-	errors := make(chan error, len(tss)/config.MaxTimeseriesPerRequest+1)
+	// TODO: this should be using main config's c.Prometheus.MaxTimeseriesPerRequest
+	errors := make(chan error, len(tss)/config.DefaultMaxTimeseriesPerRequest+1)
 	var wg sync.WaitGroup
-	for i := 0; i < len(tss); i += config.MaxTimeseriesPerRequest {
-		end := i + config.MaxTimeseriesPerRequest
+	for i := 0; i < len(tss); i += config.DefaultMaxTimeseriesPerRequest {
+		end := i + config.DefaultMaxTimeseriesPerRequest
 		if end > len(tss) {
 			end = len(tss)
 		}


### PR DESCRIPTION
Adding an option for users to configure the max number of timeseries that can be sent in each request via the  `--prometheus.max-timeseries-per-request` config flag and `max_timeseries_per_request` yaml option.

Also updated the default to 2000 from 200 as 200 seems low.