### PR TITLE
adding wal size/offset metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   option: `max_timeseries_per_request`. (#128)
 - The sidecar's max shards is now configurable via `--prometheus.max-shards`. There
   is also a matching yaml configuration option: `max_shards`. (#128)
+- Adding metrcs to capture WAL size and the current offset. (#130)
 
 ### Changed
 - The sidecar's WAL-reader addresses several race conditions by monitoring

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.samples.produced | counter | number of samples (i.e., points) read from the prometheus WAL | |
 | sidecar.queue.size | gauge | number of samples (i.e., points) standing in a queue waiting to export | |
 | sidecar.series.dropped | counter | number of points dropped because of missing metadata | (key_reason:target_not_found/metadata_not_found)|
+| sidecar.wal.size | gauge | size of the prometheus WAL | |
+| sidecar.wal.offset | gauge | current offset in the prometheus WAL | |
 
 
 ## Upstream


### PR DESCRIPTION
These metrics will let us calculate when the sidecar is falling behind on exporting data.