### PR TITLE
Update README for 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The sidecar's WAL-reader addresses several race conditions by monitoring
   Prometheus for readiness and the current segment number during WAL segment
   transitions. (#118)
+- The yaml section named "log_config" was inconsistent, has been renamed "log". ()  
 
 ### Removed
 - Remove the use_meta_labels parameter. (#125)

--- a/README.md
+++ b/README.md
@@ -181,69 +181,105 @@ below:
 ```
 usage: opentelemetry-prometheus-sidecar [<flags>]
 
-The OpenTelemetry Prometheus sidecar runs alongside the Prometheus (https://prometheus.io/) Server and sends metrics
-data to an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
+The OpenTelemetry Prometheus sidecar runs alongside the Prometheus
+(https://prometheus.io/) Server and sends metrics data to an OpenTelemetry
+(https://opentelemetry.io) Protocol endpoint.
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
       --version                  Show application version.
       --config-file=CONFIG-FILE  A configuration file.
       --destination.endpoint=DESTINATION.ENDPOINT  
-                                 Destination address of a OpenTelemetry Metrics protocol gRPC endpoint (e.g.,
-                                 https://host:port). Use "http" (not "https") for an insecure connection.
+                                 Destination address of a OpenTelemetry Metrics
+                                 protocol gRPC endpoint (e.g.,
+                                 https://host:port). Use "http" (not "https")
+                                 for an insecure connection.
       --destination.attribute=DESTINATION.ATTRIBUTE ...  
-                                 Destination resource attributes attached to OTLP data (e.g., MyResource=Value1).
-                                 May be repeated.
+                                 Destination resource attributes attached to
+                                 OTLP data (e.g., MyResource=Value1). May be
+                                 repeated.
       --destination.header=DESTINATION.HEADER ...  
-                                 Destination headers used for OTLP requests (e.g., MyHeader=Value1). May be
-                                 repeated.
+                                 Destination headers used for OTLP requests
+                                 (e.g., MyHeader=Value1). May be repeated.
       --destination.timeout=DESTINATION.TIMEOUT  
-                                 Destination timeout used for OTLP Export() requests
+                                 Destination timeout used for OTLP Export()
+                                 requests
+      --destination.compression=DESTINATION.COMPRESSION  
+                                 Destination compression used for OTLP requests
+                                 (e.g., snappy, gzip, none).
       --diagnostics.endpoint=DIAGNOSTICS.ENDPOINT  
-                                 Diagnostics address of a OpenTelemetry Metrics protocol gRPC endpoint (e.g.,
-                                 https://host:port). Use "http" (not "https") for an insecure connection.
+                                 Diagnostics address of a OpenTelemetry Metrics
+                                 protocol gRPC endpoint (e.g.,
+                                 https://host:port). Use "http" (not "https")
+                                 for an insecure connection.
       --diagnostics.attribute=DIAGNOSTICS.ATTRIBUTE ...  
-                                 Diagnostics resource attributes attached to OTLP data (e.g., MyResource=Value1).
-                                 May be repeated.
-      --diagnostics.header=DIAGNOSTICS.HEADER ...  
-                                 Diagnostics headers used for OTLP requests (e.g., MyHeader=Value1). May be
+                                 Diagnostics resource attributes attached to
+                                 OTLP data (e.g., MyResource=Value1). May be
                                  repeated.
+      --diagnostics.header=DIAGNOSTICS.HEADER ...  
+                                 Diagnostics headers used for OTLP requests
+                                 (e.g., MyHeader=Value1). May be repeated.
       --diagnostics.timeout=DIAGNOSTICS.TIMEOUT  
-                                 Diagnostics timeout used for OTLP Export() requests
+                                 Diagnostics timeout used for OTLP Export()
+                                 requests
+      --diagnostics.compression=DIAGNOSTICS.COMPRESSION  
+                                 Diagnostics compression used for OTLP requests
+                                 (e.g., snappy, gzip, none).
       --prometheus.wal=PROMETHEUS.WAL  
-                                 Directory from where to read the Prometheus TSDB WAL. Default: data/wal
+                                 Directory from where to read the Prometheus
+                                 TSDB WAL. Default: data/wal
       --prometheus.endpoint=PROMETHEUS.ENDPOINT  
-                                 Endpoint where Prometheus hosts its UI, API, and serves its own metrics. Default:
+                                 Endpoint where Prometheus hosts its UI, API,
+                                 and serves its own metrics. Default:
                                  http://127.0.0.1:9090/
       --prometheus.max-point-age=PROMETHEUS.MAX-POINT-AGE  
-                                 Skip points older than this, to assist recovery. Default: 25h0m0s
+                                 Skip points older than this, to assist
+                                 recovery. Default: 25h0m0s
       --prometheus.max-timeseries-per-request=PROMETHEUS.MAX-TIMESERIES-PER-REQUEST  
-                                 Send at most this number of timeseries per request. Default: 2000
-      --admin.port=ADMIN.PORT    Administrative port this process listens on. Default: 9091
+                                 Send at most this number of timeseries per
+                                 request. Default: 2000
+      --prometheus.max-shards=PROMETHEUS.MAX-SHARDS  
+                                 Max number of shards, i.e. amount of
+                                 concurrency. Default: 2000
+      --admin.port=ADMIN.PORT    Administrative port this process listens on.
+                                 Default: 9091
       --admin.listen-ip=ADMIN.LISTEN-IP  
-                                 Administrative IP address this process listens on. Default: 0.0.0.0
+                                 Administrative IP address this process listens
+                                 on. Default: 0.0.0.0
       --security.root-certificate=SECURITY.ROOT-CERTIFICATE ...  
-                                 Root CA certificate to use for TLS connections, in PEM format (e.g., root.crt). May
-                                 be repeated.
+                                 Root CA certificate to use for TLS connections,
+                                 in PEM format (e.g., root.crt). May be
+                                 repeated.
       --opentelemetry.metrics-prefix=OPENTELEMETRY.METRICS-PREFIX  
-                                 Customized prefix for exporter metrics. If not set, none will be used
-      --opentelemetry.use-meta-labels  
-                                 Prometheus target labels prefixed with __meta_ map into labels.
-      --filter=FILTER ...        PromQL metric and label matcher which must pass for a series to be forwarded to
-                                 OpenTelemetry. If repeated, the series must pass any of the filter sets to be
-                                 forwarded.
+                                 Customized prefix for exporter metrics. If not
+                                 set, none will be used
+      --filter=FILTER ...        PromQL metric and label matcher which must pass
+                                 for a series to be forwarded to OpenTelemetry.
+                                 If repeated, the series must pass any of the
+                                 filter sets to be forwarded.
       --startup.delay=STARTUP.DELAY  
-                                 Delay at startup to allow Prometheus its initial scrape. Default: 1m0s
+                                 Delay at startup to allow Prometheus its
+                                 initial scrape. Default: 1m0s
       --startup.timeout=STARTUP.TIMEOUT  
-                                 Timeout at startup to allow the endpoint to become available. Default: 5m0s
-      --log.level=LOG.LEVEL      Only log messages with the given severity or above. One of: [debug, info, warn,
-                                 error]
-      --log.format=LOG.FORMAT    Output format of log messages. One of: [logfmt, json]
-      --log.verbose=LOG.VERBOSE  Verbose logging level: 0 = off, 1 = some, 2 = more; 1 is automatically added when
-                                 log.level is 'debug'; impacts logging from the gRPC library in particular
+                                 Timeout at startup to allow the endpoint to
+                                 become available. Default: 5m0s
+      --healthcheck.period=HEALTHCHECK.PERIOD  
+                                 Period for internal health checking; set at a
+                                 minimum to the shortest Promethues scrape
+                                 period
+      --log.level=LOG.LEVEL      Only log messages with the given severity or
+                                 above. One of: [debug, info, warn, error]
+      --log.format=LOG.FORMAT    Output format of log messages. One of: [logfmt,
+                                 json]
+      --log.verbose=LOG.VERBOSE  Verbose logging level: 0 = off, 1 = some, 2 =
+                                 more; 1 is automatically added when log.level
+                                 is 'debug'; impacts logging from the gRPC
+                                 library in particular
       --disable-supervisor       Disable the supervisor.
-      --disable-diagnostics      Disable diagnostics by default; if unset, diagnostics will be auto-configured to
-                                 the primary destination
+      --disable-diagnostics      Disable diagnostics by default; if unset,
+                                 diagnostics will be auto-configured to the
+                                 primary destination
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -363,10 +363,10 @@ Metrics from the subordinate process can help identify issues once the first met
 
 | Metric Name | Metric Type | Description | Additional Tags |
 | --- | --- | --- | ---|
-| sidecar.connect.duration{.count} | histogram/counter | how many attempts to connect (and how long) | (error:true/false) |
-| sidecar.export.duration{.count} | histogram/counter | how many attempts to export (and how long) | (error:true/false) |
-| sidecar.monitor.duration{.count} | histogram/counter | how many attempts to scrape Prometheus /metrics (and how long) | (error:true/false) |
-| sidecar.metadata.fetch.duration{.count} | histogram/counter | how many attempts to fetch metadata from Prometheus (and how long) | (error:true/false) |
+| sidecar.connect.duration | histogram | how many attempts to connect (and how long) | (error:true/false) |
+| sidecar.export.duration | histogram | how many attempts to export (and how long) | (error:true/false) |
+| sidecar.monitor.duration | histogram | how many attempts to scrape Prometheus /metrics (and how long) | (error:true/false) |
+| sidecar.metadata.fetch.duration | histogram | how many attempts to fetch metadata from Prometheus (and how long) | (error:true/false) |
 | sidecar.queue.outcome | counter | outcome of the sample in the queue | (outcome: success, failed, retry, aborted) |
 | sidecar.queue.capacity | gauge | number of available slots for samples (i.e., points) in the queue, counts buffer size times current number of shards | |
 | sidecar.queue.running | gauge | number of running shards, those which have not exited | |

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ deployment or deploy the sidecar without using Helm.
 ### Configuration
 
 Most sidecar configuration settings can be set through flags or a yaml
-configuration file. To see all available flags, run
-`opentelemetry-prometheus-sidecar --help`.  The printed usage is shown
-below:
+configuration file.  [See the example configuration yaml file
+here](./config/sidecar.example.yaml).  To see all available
+command-line flags, run `opentelemetry-prometheus-sidecar --help`.
+The printed usage is shown below:
 
 ```
 usage: opentelemetry-prometheus-sidecar [<flags>]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ server:
     volumeMounts:
     - name: storage-volume
       mountPath: /data
+    ports:
+    - name: admin-port
+      containerPort: 9091 
+    livenessProbe:
+      httpGet:
+        path: /-/health
+        port: admin-port
+      periodSeconds: 30
+      failureThreshold: 2
 ```
 
 The [upstream Stackdriver Prometheus sidecar Kubernetes
@@ -306,6 +315,22 @@ Note:
 
 * All `static_metadata` entries must have `type` specified.
 * If `value_type` is specified, it will override the default value type for counters and gauges. All Prometheus metrics have a default type of double.
+
+## Monitoring
+
+When run in the default configuration, the sidecar will self-monitor for liveness and kill the process when it becomes unhealthy.  Sidecar liveness can be monitored directly using the `/-/health` endpoint.  We recommend a period of 30 seconds and `failureThreshold: 2`, for example in your Kubernetes deployment:
+
+```
+    ports:
+    - name: admin-port
+      containerPort: 9091 
+    livenessProbe:
+      httpGet:
+        path: /-/health
+        port: admin-port
+      periodSeconds: 30
+      failureThreshold: 2
+```
 
 ## Diagnostics
 

--- a/config/config.go
+++ b/config/config.go
@@ -284,7 +284,7 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 		a.Flag(lowerPrefix+".timeout", upperPrefix+" timeout used for OTLP Export() requests").
 			DurationVar(&op.Timeout.Duration)
 
-		a.Flag(lowerPrefix+".compression", upperPrefix+" compression used for OTLP requests (e.g., snappy).").
+		a.Flag(lowerPrefix+".compression", upperPrefix+" compression used for OTLP requests (e.g., snappy, gzip, none).").
 			StringVar(&op.Compression)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -183,7 +183,7 @@ type MainConfig struct {
 	Filters        []string               `json:"filters"`
 	MetricRenames  []MetricRenamesConfig  `json:"metric_renames"`
 	StaticMetadata []StaticMetadataConfig `json:"static_metadata"`
-	LogConfig      LogConfig              `json:"log_config"`
+	LogConfig      LogConfig              `json:"log"`
 
 	DisableSupervisor  bool `json:"disable_supervisor"`
 	DisableDiagnostics bool `json:"disable_diagnostics"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -256,7 +256,7 @@ filters:
 prometheus:
   wal: bad-guy
 
-log_config:
+log:
   format: json
   level: error
 `,
@@ -368,7 +368,7 @@ prometheus:
 startup_delay: 30s
 startup_timeout: 33s
 
-log_config:
+log:
   level: warn
   format: json
 

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -93,7 +93,7 @@ func Example() {
 	//       "help": "Number of bits transferred by this process."
 	//     }
 	//   ],
-	//   "log_config": {
+	//   "log": {
 	//     "level": "debug",
 	//     "format": "json",
 	//     "verbose": 1

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -111,7 +111,7 @@ startup_delay: 30s
 startup_timeout: 300s
 
 # Control the format and level of console-logging output:
-log_config:
+log:
   level: debug
   format: json
   verbose: 1

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -41,9 +41,6 @@ var (
 	)
 	keyReason = label.Key("key_reason")
 
-	droppedSeriesTargetNotFound = droppedSeries.Bind(
-		keyReason.String("target_not_found"),
-	)
 	droppedSeriesMetadataNotFound = droppedSeries.Bind(
 		keyReason.String("metadata_not_found"),
 	)

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -72,12 +72,6 @@ var (
 			"The number of bytes read from WAL segments",
 		),
 	)
-	segmentRestartCounter = sidecar.OTelMeterMust.NewInt64Counter(
-		"sidecar.segment.restarts",
-		metric.WithDescription(
-			"The number of attempts to restart reading the WAL",
-		),
-	)
 
 	ErrRestartReader = errors.New("sidecar fell behind, restarting reader")
 )


### PR DESCRIPTION
Remove several sections that are less relevant given how far this code has diverged from the Stackdriver codebase.
This updates the command-line help and internal metrics lists.
This removes README text related to the targets cache.
This adds details on using liveness checks.