### PR TITLE
Close the Prometheus reader and restart the WAL tailer on segment-transition errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - Added support for the Prometheus reader to be restarted when an invalid segment
-  is encountered (#133)
+  is encountered to safely mitigate a race with WAL-segment removal (#133)
 
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+- Added support for the Prometheus reader to be restarted when an invalid segment
+  is encountered (#133)
+
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added
 - Automatically set (the same) `service.instance.id` for Destination/Diagnostics

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -302,6 +302,7 @@ func Main() bool {
 		if err := g.Run(); err != nil {
 			// TODO: don't use a string compare here
 			if strings.Contains(err.Error(), "truncated WAL segment") {
+				level.Error(logger).Log("msg", "restarting reader", "err", err)
 				startOffset, err = readWriteStartOffset(cfg, logger)
 				if err != nil {
 					return false

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -300,8 +299,7 @@ func Main() bool {
 
 	for {
 		if err := g.Run(); err != nil {
-			// TODO: don't use a string compare here
-			if strings.Contains(err.Error(), "truncated WAL segment") {
+			if err == tail.ErrRestartReader {
 				level.Error(logger).Log("msg", "restarting reader", "err", err)
 				startOffset, err = readWriteStartOffset(cfg, logger)
 				if err != nil {

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -96,6 +96,10 @@ type PrometheusReader struct {
 	extraLabels          labels.Labels
 }
 
+func (r *PrometheusReader) Close() error {
+	return r.tailer.Close()
+}
+
 func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 	level.Info(r.logger).Log("msg", "starting Prometheus reader")
 

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -72,6 +72,12 @@ var (
 			"The number of bytes read from WAL segments",
 		),
 	)
+	segmentErrorCounter = sidecar.OTelMeterMust.NewInt64Counter(
+		"sidecar.segment.errors",
+		metric.WithDescription(
+			"The number of invalid segments errors encountered",
+		),
+	)
 
 	ErrRestartReader = errors.New("sidecar fell behind, restarting reader")
 )
@@ -397,6 +403,7 @@ func (t *Tailer) Read(b []byte) (int, error) {
 					"offset", currentOffset,
 				)
 			})
+			segmentErrorCounter.Add(t.ctx, 1)
 			return 0, errors.Errorf(
 				"truncated WAL segment %d @ %d",
 				currentSegment,

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -396,19 +396,13 @@ func (t *Tailer) Read(b []byte) (int, error) {
 			// If the promSeg is more than 1 ahead of the reader but
 			// the block size is not aligned, we have a serious
 			// inconsistency.
-			doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
-				level.Error(t.logger).Log(
-					"msg", "truncated WAL segment",
-					"segment", currentSegment,
-					"offset", currentOffset,
-				)
-			})
-			segmentErrorCounter.Add(t.ctx, 1)
-			return 0, errors.Errorf(
-				"truncated WAL segment %d @ %d",
-				currentSegment,
-				currentOffset,
+			level.Error(t.logger).Log(
+				"msg", "truncated WAL segment",
+				"segment", currentSegment,
+				"offset", currentOffset,
 			)
+			segmentErrorCounter.Add(t.ctx, 1)
+			return 0, ErrRestartReader
 		}
 
 		if promSeg < currentSegment {


### PR DESCRIPTION
This PR closes the Prometheus reader and re-opens it if the reader hits an invalid segment problem. This allows the reader to continue on after it hits this issue. 

Still some todos but would love some feedback on the work so far.