### PR TITLE
Sidecar waits for complete scrape(s) at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+- Sidecar waits for the first scrape to complete before entering its run state. ()
+- New setting `--prometheus.longest-interval` supports configuring the longest
+  interval to wait for at startup.
+  
+### Removed
+- The `--startup.delay` setting has been removed in favor of monitoring when 
+  Prometheus actually finishes its first scrapes.
+
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added
 - Automatically set (the same) `service.instance.id` for Destination/Diagnostics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ### Added
-- Sidecar waits for the first scrape to complete before entering its run state. ()
-- New setting `--prometheus.longest-interval` supports configuring the longest
-  interval to wait for at startup.
+- Sidecar waits for the first scrapes to complete before entering its 
+  run state. ()
+- New setting `--prometheus.scrape-interval` supports configuring scrape
+  interval(s) to wait for at startup. ()
   
 ### Removed
 - The `--startup.delay` setting has been removed in favor of monitoring when 
-  Prometheus actually finishes its first scrapes.
+  Prometheus actually finishes its first scrapes. ()
 
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - Sidecar waits for the first scrapes to complete before entering its 
-  run state. ()
+  run state. (#134)
 - New setting `--prometheus.scrape-interval` supports configuring scrape
-  interval(s) to wait for at startup. ()
+  interval(s) to wait for at startup. (#134)
   
 ### Removed
 - The `--startup.delay` setting has been removed in favor of monitoring when 
-  Prometheus actually finishes its first scrapes. ()
+  Prometheus actually finishes its first scrapes. (#134)
 
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ server:
       mountPath: /data
     ports:
     - name: admin-port
-      containerPort: 9091 
+      containerPort: 9091
     livenessProbe:
       httpGet:
         path: /-/health
@@ -215,6 +215,10 @@ Flags:
       --prometheus.max-shards=PROMETHEUS.MAX-SHARDS
                                  Max number of shards, i.e. amount of
                                  concurrency. Default: 2000
+      --prometheus.longest-interval=PROMETHEUS.LONGEST-INTERVAL
+                                 Delay at startup until Prometheus completes a
+                                 scrape for this period. Default is unset, meaning
+                                 wait for the first scrape to complete
       --admin.port=ADMIN.PORT    Administrative port this process listens on.
                                  Default: 9091
       --admin.listen-ip=ADMIN.LISTEN-IP
@@ -231,9 +235,6 @@ Flags:
                                  for a series to be forwarded to OpenTelemetry.
                                  If repeated, the series must pass any of the
                                  filter sets to be forwarded.
-      --startup.delay=STARTUP.DELAY
-                                 Delay at startup to allow Prometheus its
-                                 initial scrape. Default: 1m0s
       --startup.timeout=STARTUP.TIMEOUT
                                  Timeout at startup to allow the endpoint to
                                  become available. Default: 5m0s
@@ -323,7 +324,7 @@ When run in the default configuration, the sidecar will self-monitor for livenes
 ```
     ports:
     - name: admin-port
-      containerPort: 9091 
+      containerPort: 9091
     livenessProbe:
       httpGet:
         path: /-/health

--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ Flags:
       --prometheus.max-shards=PROMETHEUS.MAX-SHARDS
                                  Max number of shards, i.e. amount of
                                  concurrency. Default: 2000
-      --prometheus.longest-interval=PROMETHEUS.LONGEST-INTERVAL
+      --prometheus.scrape-interval=PROMETHEUS.SCRAPE-INTERVAL ...  
                                  Delay at startup until Prometheus completes a
-                                 scrape for this period. Default is unset, meaning
-                                 wait for the first scrape to complete
+                                 scrape for this interval. Default waits for the
+                                 first scrape to complete, multiple intervals
+                                 can be set
       --admin.port=ADMIN.PORT    Administrative port this process listens on.
                                  Default: 9091
       --admin.listen-ip=ADMIN.LISTEN-IP
@@ -269,12 +270,13 @@ resource attributes, are combined from both sources.
 
 #### Startup safety
 
-The sidecar waits until Prometheus finishes its first scrapes to begin
-processing the WAL, to ensure that target information is available
-before the sidecar tries loading its metadata cache.
+The sidecar waits until Prometheus finishes its first scrape(s) to
+begin processing the WAL, to ensure that target information is
+available before the sidecar tries loading its metadata cache.
 
 When multiple scrape intervals are in use, all intervals should be
-monitored.  @@@
+monitored.  Use the `--prometheus.scrape-interval=DURATION` flag to
+set scrape intervals to monitor at startup.
 
 #### Resources
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,15 @@ parameter values, with one exception.  Configurations that support
 a map from string to string, including both request headers and
 resource attributes, are combined from both sources.
 
+#### Startup safety
+
+The sidecar waits until Prometheus finishes its first scrapes to begin
+processing the WAL, to ensure that target information is available
+before the sidecar tries loading its metadata cache.
+
+When multiple scrape intervals are in use, all intervals should be
+monitored.  @@@
+
 #### Resources
 
 Use the `--destination.attribute=KEY=VALUE` flag to add additional resource attributes to all exported timeseries.

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -26,8 +26,8 @@ import (
 	common "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/common/v1"
 	metrics "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/metrics/v1"
 	traces "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/trace/v1"
-	"go.opentelemetry.io/otel/semconv"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/semconv"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	grpcMetadata "google.golang.org/grpc/metadata"
@@ -197,7 +197,6 @@ func TestE2E(t *testing.T) {
 		append(e2eTestMainCommonFlags,
 			"--prometheus.wal", path.Join(dataDir, "wal"),
 			"--destination.attribute=service.name=Service",
-			"--startup.delay=1s",
 		)...,
 	)
 	sideCmd.Env = append(os.Environ(), "RUN_MAIN=1")

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -139,6 +139,9 @@ func Main() bool {
 	readyCfg := config.PromReady{
 		Logger:  log.With(logger, "component", "prom_ready"),
 		PromURL: promURL,
+
+		// This may be unset.
+		LongestInterval: cfg.Prometheus.LongestInterval.Duration,
 	}
 
 	metadataURL, err := promURL.Parse(metadata.DefaultEndpointPath)

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -69,7 +69,6 @@ func TestStartupInterrupt(t *testing.T) {
 		append(e2eTestMainCommonFlags,
 			"--prometheus.wal=testdata/wal",
 			"--log.level=debug",
-			"--startup.delay=1s",
 		)...)
 
 	cmd.Env = append(os.Environ(), "RUN_MAIN=1")
@@ -240,7 +239,6 @@ func TestSuperStackDump(t *testing.T) {
 		append(e2eTestMainSupervisorFlags,
 			"--prometheus.wal=testdata/wal",
 			"--healthcheck.period=1s",
-			"--startup.delay=0s",
 			"--log.level=debug",
 		)...)
 

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	traces "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/trace/v1"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/internal/promtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,16 +40,11 @@ func TestMain(m *testing.M) {
 }
 
 func runPrometheusService(ts *testServer) {
-	// Note: This does not expose the necessary metric needed to start the WAL
-	// tailer, it only exposes the readiness handler needed to test startup.
-	mux := http.NewServeMux()
-	mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	fp := promtest.NewFakePrometheus()
 	address := fmt.Sprint("0.0.0.0:19093")
 	server := &http.Server{
 		Addr:    address,
-		Handler: mux,
+		Handler: fp.ServeMux(),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/config/config.go
+++ b/config/config.go
@@ -537,7 +537,7 @@ func (d DurationConfig) MarshalJSON() ([]byte, error) {
 // places.  It is not parsed from the config file or command-line, it
 // is here to avoid a test package cycle, primarily.
 type PromReady struct {
-	Logger    log.Logger
-	PromURL   *url.URL
-	Intervals []time.Duration
+	Logger          log.Logger
+	PromURL         *url.URL
+	LongestInterval time.Duration
 }

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/go-kit/kit/log"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/metadata"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/snappy"
 	"github.com/pkg/errors"
@@ -533,4 +534,13 @@ func (d *DurationConfig) UnmarshalJSON(data []byte) error {
 
 func (d DurationConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Duration.String())
+}
+
+// PromReady is used for prometheus.WaitForReady() in several
+// places.  It is not parsed from the config file or command-line, it
+// is here to avoid a test package cycle, primarily.
+type PromReady struct {
+	Logger    log.Logger
+	PromURL   *url.URL
+	Intervals []time.Duration
 }

--- a/config/config.go
+++ b/config/config.go
@@ -308,7 +308,7 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 	a.Flag("prometheus.max-shards", fmt.Sprintf("Max number of shards, i.e. amount of concurrency. Default: %d", DefaultMaxShards)).
 		IntVar(&cfg.Prometheus.MaxShards)
 
-	a.Flag("prometheus.longest-interval", "Delay at startup until Prometheus completes a scrape for this period. Default is unset, meaning wait for any scrape to complete").
+	a.Flag("prometheus.longest-interval", "Delay at startup until Prometheus completes a scrape for this period. Default is unset, meaning wait for the first scrape to complete").
 		DurationVar(&cfg.Prometheus.LongestInterval.Duration)
 
 	a.Flag("admin.port", "Administrative port this process listens on. Default: "+fmt.Sprint(DefaultAdminPort)).

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,10 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 	// PrometheusCurrentSegmentMetricName names an internal gauge
 	// exposed by Prometheus (having no labels).
 	PrometheusCurrentSegmentMetricName = "prometheus_tsdb_wal_segment_current"
+
+	// PrometheusTargetIntervalLengthName is an internal histogram
+	// indicating how long the interval between scrapes.
+	PrometheusTargetIntervalLengthName = "prometheus_target_interval_length_seconds"
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -160,7 +160,7 @@ type PromConfig struct {
 	MaxPointAge             DurationConfig `json:"max_point_age"`
 	MaxTimeseriesPerRequest int            `json:"max_timeseries_per_request"`
 	MaxShards               int            `json:"max_shards"`
-	LongestInterval         DurationConfig `json:"longest_interval"`
+	ScrapeIntervals         []string       `json:"scrape_intervals"`
 }
 
 type OTelConfig struct {
@@ -225,7 +225,7 @@ func DefaultMainConfig() MainConfig {
 			MaxPointAge:             DurationConfig{DefaultMaxPointAge},
 			MaxTimeseriesPerRequest: DefaultMaxTimeseriesPerRequest,
 			MaxShards:               DefaultMaxShards,
-			LongestInterval:         DurationConfig{0},
+			ScrapeIntervals:         nil,
 		},
 		Admin: AdminConfig{
 			Port:              DefaultAdminPort,
@@ -308,8 +308,8 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 	a.Flag("prometheus.max-shards", fmt.Sprintf("Max number of shards, i.e. amount of concurrency. Default: %d", DefaultMaxShards)).
 		IntVar(&cfg.Prometheus.MaxShards)
 
-	a.Flag("prometheus.longest-interval", "Delay at startup until Prometheus completes a scrape for this period. Default is unset, meaning wait for the first scrape to complete").
-		DurationVar(&cfg.Prometheus.LongestInterval.Duration)
+	a.Flag("prometheus.scrape-interval", "Delay at startup until Prometheus completes a scrape for this interval. Default waits for the first scrape to complete, multiple intervals can be set").
+		StringsVar(&cfg.Prometheus.ScrapeIntervals)
 
 	a.Flag("admin.port", "Administrative port this process listens on. Default: "+fmt.Sprint(DefaultAdminPort)).
 		IntVar(&cfg.Admin.Port)
@@ -539,5 +539,5 @@ func (d DurationConfig) MarshalJSON() ([]byte, error) {
 type PromReady struct {
 	Logger          log.Logger
 	PromURL         *url.URL
-	LongestInterval time.Duration
+	ScrapeIntervals []time.Duration
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -161,8 +161,8 @@ destination:
 
 prometheus:
   wal: wal-eeee
+  longest_interval: 1333s
 
-startup_delay: 1333s
 startup_timeout: 1777s
 `,
 			nil,
@@ -175,6 +175,9 @@ startup_timeout: 1777s
 					},
 					MaxTimeseriesPerRequest: 2000,
 					MaxShards:               2000,
+					LongestInterval: DurationConfig{
+						1333 * time.Second,
+					},
 				},
 				Admin: AdminConfig{
 					ListenIP:          config.DefaultAdminListenIP,
@@ -207,9 +210,6 @@ startup_timeout: 1777s
 				LogConfig: LogConfig{
 					Level:  "info",
 					Format: "logfmt",
-				},
-				StartupDelay: DurationConfig{
-					1333 * time.Second,
 				},
 				StartupTimeout: DurationConfig{
 					1777 * time.Second,
@@ -261,7 +261,6 @@ log:
   level: error
 `,
 			[]string{
-				"--startup.delay=1333s",
 				"--startup.timeout=1777s",
 				"--destination.attribute", "c=d",
 				"--destination.header", "g=h",
@@ -270,6 +269,7 @@ log:
 				"--prometheus.max-point-age", "10h",
 				"--prometheus.max-timeseries-per-request", "5",
 				"--prometheus.max-shards", "10",
+				"--prometheus.longest-interval=1333s",
 				"--log.level=warning",
 				"--healthcheck.period=17s",
 				"--diagnostics.endpoint", "https://look.here",
@@ -286,6 +286,9 @@ log:
 					},
 					MaxTimeseriesPerRequest: 5,
 					MaxShards:               10,
+					LongestInterval: DurationConfig{
+						1333 * time.Second,
+					},
 				},
 				Admin: AdminConfig{
 					ListenIP:          config.DefaultAdminListenIP,
@@ -327,9 +330,6 @@ log:
 					Level:  "warning",
 					Format: "json",
 				},
-				StartupDelay: DurationConfig{
-					1333 * time.Second,
-				},
 				StartupTimeout: DurationConfig{
 					1777 * time.Second,
 				},
@@ -364,8 +364,8 @@ prometheus:
   max_point_age: 72h
   max_timeseries_per_request: 10
   max_shards: 20
+  longest_interval: 30s
 
-startup_delay: 30s
 startup_timeout: 33s
 
 log:
@@ -415,9 +415,6 @@ static_metadata:
 					Port:              9999,
 					HealthCheckPeriod: DurationConfig{10 * time.Second},
 				},
-				StartupDelay: DurationConfig{
-					30 * time.Second,
-				},
 				StartupTimeout: DurationConfig{
 					33 * time.Second,
 				},
@@ -429,6 +426,9 @@ static_metadata:
 					},
 					MaxTimeseriesPerRequest: 10,
 					MaxShards:               20,
+					LongestInterval: DurationConfig{
+						30 * time.Second,
+					},
 				},
 				OpenTelemetry: OTelConfig{
 					MetricsPrefix: "prefix.",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -161,7 +161,7 @@ destination:
 
 prometheus:
   wal: wal-eeee
-  longest_interval: 1333s
+  scrape_intervals: [22m13s]
 
 startup_timeout: 1777s
 `,
@@ -175,8 +175,8 @@ startup_timeout: 1777s
 					},
 					MaxTimeseriesPerRequest: 2000,
 					MaxShards:               2000,
-					LongestInterval: DurationConfig{
-						1333 * time.Second,
+					ScrapeIntervals: []string{
+						(1333 * time.Second).String(),
 					},
 				},
 				Admin: AdminConfig{
@@ -269,7 +269,7 @@ log:
 				"--prometheus.max-point-age", "10h",
 				"--prometheus.max-timeseries-per-request", "5",
 				"--prometheus.max-shards", "10",
-				"--prometheus.longest-interval=1333s",
+				"--prometheus.scrape-interval=22m13s",
 				"--log.level=warning",
 				"--healthcheck.period=17s",
 				"--diagnostics.endpoint", "https://look.here",
@@ -286,8 +286,8 @@ log:
 					},
 					MaxTimeseriesPerRequest: 5,
 					MaxShards:               10,
-					LongestInterval: DurationConfig{
-						1333 * time.Second,
+					ScrapeIntervals: []string{
+						(1333 * time.Second).String(),
 					},
 				},
 				Admin: AdminConfig{
@@ -364,7 +364,7 @@ prometheus:
   max_point_age: 72h
   max_timeseries_per_request: 10
   max_shards: 20
-  longest_interval: 30s
+  scrape_intervals: [30s]
 
 startup_timeout: 33s
 
@@ -426,8 +426,8 @@ static_metadata:
 					},
 					MaxTimeseriesPerRequest: 10,
 					MaxShards:               20,
-					LongestInterval: DurationConfig{
-						30 * time.Second,
+					ScrapeIntervals: []string{
+						(30 * time.Second).String(),
 					},
 				},
 				OpenTelemetry: OTelConfig{

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -42,7 +42,8 @@ func Example() {
 	//     "wal": "/volume/wal",
 	//     "max_point_age": "72h0m0s",
 	//     "max_timeseries_per_request": 2000,
-	//     "max_shards": 2000
+	//     "max_shards": 2000,
+	//     "longest_interval": "33s"
 	//   },
 	//   "opentelemetry": {
 	//     "metrics_prefix": "prefix."
@@ -69,7 +70,6 @@ func Example() {
 	//     "timeout": "1m0s",
 	//     "compression": "snappy"
 	//   },
-	//   "startup_delay": "30s",
 	//   "startup_timeout": "5m0s",
 	//   "filters": [
 	//     "metric{label=value}",

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -43,7 +43,10 @@ func Example() {
 	//     "max_point_age": "72h0m0s",
 	//     "max_timeseries_per_request": 2000,
 	//     "max_shards": 2000,
-	//     "longest_interval": "33s"
+	//     "scrape_intervals": [
+	//       "30s",
+	//       "60s"
+	//     ]
 	//   },
 	//   "opentelemetry": {
 	//     "metrics_prefix": "prefix."

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -41,6 +41,11 @@ prometheus:
   # Max number of shards, i.e. amount of concurrency
   max_shards: 2000
 
+  # Longest interval, when set, is used to delay startup.  If set, 
+  # the sidecar will wait until the first scrape completes with
+  # this interval
+  longest_interval: 33s
+
 # OpenTelemetry settings:
 opentelemetry:
   # Metrics prefix is prepended to all exported metric names:
@@ -101,10 +106,6 @@ static_metadata:
   type:       counter
   value_type: int64
   help:       Number of bits transferred by this process.
-
-# Startup delay determines how long to wait before processing new
-# write-ahead-log entries after startup:
-startup_delay: 30s
 
 # Startup timeout determines how long to wait for the endpoint to
 # become available once before entering the initial run state.

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -41,10 +41,10 @@ prometheus:
   # Max number of shards, i.e. amount of concurrency
   max_shards: 2000
 
-  # Longest interval, when set, is used to delay startup.  If set, 
+  # Scrape intervals, when set, are used to delay startup.  If set, 
   # the sidecar will wait until the first scrape completes with
   # this interval
-  longest_interval: 33s
+  scrape_intervals: [30s, 60s]
 
 # OpenTelemetry settings:
 opentelemetry:

--- a/internal/promtest/fake.go
+++ b/internal/promtest/fake.go
@@ -2,6 +2,7 @@ package promtest
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,22 +12,29 @@ import (
 )
 
 type FakePrometheus struct {
-	lock    sync.Mutex
-	ready   bool
-	segment int
-	server  *httptest.Server
-	URL     *url.URL
+	lock      sync.Mutex
+	ready     bool
+	segment   int
+	intervals []int
+	mux       *http.ServeMux
+	// server    *httptest.Server
+	// URL       *url.URL
 }
 
 func NewFakePrometheus() *FakePrometheus {
-	const name = config.PrometheusCurrentSegmentMetricName
+	const segmentName = config.PrometheusCurrentSegmentMetricName
+	const scrapeIntervalName = config.PrometheusTargetIntervalLengthName
+	const scrapeIntervalSum = scrapeIntervalName + "_sum"
+	const scrapeIntervalCount = scrapeIntervalName + "_count"
+
 	fp := &FakePrometheus{
-		ready:   true,
-		segment: 0,
+		ready:     true,
+		segment:   0,
+		intervals: []int{30},
+		mux:       http.NewServeMux(),
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+	fp.mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
 		fp.lock.Lock()
 		defer fp.lock.Unlock()
 		if fp.ready {
@@ -35,29 +43,53 @@ func NewFakePrometheus() *FakePrometheus {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 	})
-	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+	fp.mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		fp.lock.Lock()
 		defer fp.lock.Unlock()
+
 		_, err := w.Write([]byte(fmt.Sprintf(`
 # HELP %s Current segment.
 # TYPE %s gauge
 %s{} %d
-`, name, name, name, fp.segment)))
+`, segmentName, segmentName, segmentName, fp.segment)))
 		if err != nil {
 			panic(err)
 		}
+
+		_, err = w.Write([]byte(fmt.Sprintf(`
+# HELP %s Scrape interval summary.
+# TYPE %s summary
+`, scrapeIntervalName, scrapeIntervalName)))
+		if err != nil {
+			panic(err)
+		}
+
+		for _, in := range fp.intervals {
+			cnt := 1 + rand.Intn(3)
+			mean := float64(in) + 0.000123
+			sum := float64(cnt) * mean
+			_, err = w.Write([]byte(fmt.Sprintf(`
+%s{interval="%ds",quantile="0.99"} %f
+%s{interval="%ds"} %f
+%s{interval="%ds"} %d
+`, scrapeIntervalName, in, mean, scrapeIntervalSum, in, sum, scrapeIntervalCount, in, cnt)))
+			if err != nil {
+				panic(err)
+			}
+		}
 	})
+	return fp
+}
 
-	fp.server = httptest.NewServer(mux)
+func (fp *FakePrometheus) Test() *url.URL {
+	server := httptest.NewServer(fp.mux)
 
-	fpu, err := url.Parse(fp.server.URL)
+	fpu, err := url.Parse(server.URL)
 	if err != nil {
 		panic(err)
 	}
 
-	fp.URL = fpu
-
-	return fp
+	return fpu
 }
 
 func (fp *FakePrometheus) SetSegment(s int) {
@@ -72,4 +104,15 @@ func (fp *FakePrometheus) SetReady(r bool) {
 	defer fp.lock.Unlock()
 
 	fp.ready = r
+}
+
+func (fp *FakePrometheus) SetIntervals(is ...int) {
+	fp.lock.Lock()
+	defer fp.lock.Unlock()
+
+	fp.intervals = is
+}
+
+func (fp *FakePrometheus) ServeMux() *http.ServeMux {
+	return fp.mux
 }

--- a/internal/promtest/fake.go
+++ b/internal/promtest/fake.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 )
 
 type FakePrometheus struct {
@@ -17,8 +18,6 @@ type FakePrometheus struct {
 	segment   int
 	intervals []int
 	mux       *http.ServeMux
-	// server    *httptest.Server
-	// URL       *url.URL
 }
 
 func NewFakePrometheus() *FakePrometheus {
@@ -90,6 +89,13 @@ func (fp *FakePrometheus) Test() *url.URL {
 	}
 
 	return fpu
+}
+
+func (fp *FakePrometheus) ReadyConfig() config.PromReady {
+	return config.PromReady{
+		Logger:  telemetry.DefaultLogger(),
+		PromURL: fp.Test(),
+	}
 }
 
 func (fp *FakePrometheus) SetSegment(s int) {

--- a/internal/promtest/fake.go
+++ b/internal/promtest/fake.go
@@ -96,7 +96,7 @@ func (fp *FakePrometheus) ReadyConfig() config.PromReady {
 	return config.PromReady{
 		Logger:          telemetry.DefaultLogger(),
 		PromURL:         fp.Test(),
-		LongestInterval: 0,
+		ScrapeIntervals: nil,
 	}
 }
 

--- a/otlp/queue_manager_test.go
+++ b/otlp/queue_manager_test.go
@@ -225,7 +225,7 @@ func TestSampleDeliverySimple(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestSampleDeliveryMultiShard(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prometheus/ready.go
+++ b/prometheus/ready.go
@@ -3,11 +3,9 @@ package prometheus
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"path"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 	"github.com/pkg/errors"
@@ -17,15 +15,7 @@ const (
 	scrapeIntervalName = config.PrometheusTargetIntervalLengthName
 )
 
-type (
-	ReadyConfig struct {
-		Logger    log.Logger
-		PromURL   *url.URL
-		Intervals []time.Duration
-	}
-)
-
-func completedFirstScrapes(inCtx context.Context, cfg ReadyConfig) error {
+func completedFirstScrapes(inCtx context.Context, cfg config.PromReady) error {
 	u := *cfg.PromURL
 	u.Path = path.Join(u.Path, "/metrics")
 
@@ -52,7 +42,7 @@ func completedFirstScrapes(inCtx context.Context, cfg ReadyConfig) error {
 	return nil
 }
 
-func WaitForReady(inCtx context.Context, cfg ReadyConfig) error {
+func WaitForReady(inCtx context.Context, cfg config.PromReady) error {
 	u := *cfg.PromURL
 	u.Path = path.Join(u.Path, "/-/ready")
 

--- a/prometheus/ready.go
+++ b/prometheus/ready.go
@@ -41,22 +41,26 @@ func completedFirstScrapes(inCtx context.Context, cfg config.PromReady) error {
 		}
 	}
 
-	if cfg.LongestInterval == 0 && foundAny {
-		// TODO: Print something about setting longest
-		// interval when there are more than one.
+	if len(cfg.ScrapeIntervals) == 0 && foundAny {
+		// TODO: After_some time passes, we can check again and if any
+		// new intervals are discovered, print a warning about configuring
+		// the --prometheus.scrape-interval setting.
 		return nil
 	}
 
-	ts := cfg.LongestInterval.String()
-	for _, ls := range foundLabelSets {
-		for _, l := range ls {
-			if l.Name == "interval" && l.Value == ts {
-				return nil
+	for _, si := range cfg.ScrapeIntervals {
+		ts := si.String()
+		for _, ls := range foundLabelSets {
+			for _, l := range ls {
+				if l.Name == "interval" && l.Value == ts {
+					return nil
+				}
 			}
 		}
+		return errors.Errorf("waiting for scrape interval %s", ts)
 	}
 
-	return errors.Errorf("waiting for longest interval: %s", ts)
+	return nil
 }
 
 func WaitForReady(inCtx context.Context, cfg config.PromReady) error {

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -19,10 +19,7 @@ func TestReady(t *testing.T) {
 	fs.SetReady(true)
 	fs.SetIntervals(30)
 
-	require.NoError(t, WaitForReady(context.Background(), ReadyConfig{
-		Logger:  logger,
-		PromURL: fs.Test(),
-	}))
+	require.NoError(t, WaitForReady(context.Background(), fs.ReadyConfig()))
 }
 
 func TestSlowStart(t *testing.T) {
@@ -38,9 +35,7 @@ func TestSlowStart(t *testing.T) {
 		fs.SetIntervals(30)
 	}()
 
-	require.NoError(t, WaitForReady(context.Background(), ReadyConfig{
-		Logger: logger, PromURL: fs.Test(),
-	}))
+	require.NoError(t, WaitForReady(context.Background(), fs.ReadyConfig()))
 }
 
 func TestNotReady(t *testing.T) {
@@ -52,10 +47,7 @@ func TestNotReady(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*config.DefaultHealthCheckTimeout)
 	defer cancel()
-	err := WaitForReady(ctx, ReadyConfig{
-		Logger:  logger,
-		PromURL: fs.Test(),
-	})
+	err := WaitForReady(ctx, fs.ReadyConfig())
 	require.Error(t, err)
 	require.Equal(t, context.DeadlineExceeded, err)
 }
@@ -70,7 +62,7 @@ func TestReadyFail(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*config.DefaultHealthCheckTimeout)
 	defer cancel()
-	err = WaitForReady(ctx, ReadyConfig{
+	err = WaitForReady(ctx, config.PromReady{
 		Logger:  logger,
 		PromURL: tu,
 	})
@@ -82,10 +74,8 @@ func TestReadyCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediate
-	err := WaitForReady(ctx, ReadyConfig{
-		Logger:  logger,
-		PromURL: fs.Test(),
-	})
+	err := WaitForReady(ctx, fs.ReadyConfig())
+
 	require.Error(t, err)
 	require.Equal(t, context.Canceled, err)
 }

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -118,10 +118,8 @@ func TestReadySpecificIntervalWait(t *testing.T) {
 	fs := promtest.NewFakePrometheus()
 	fs.SetIntervals(19 * time.Second) // Not the one we want
 
-	const interval = 79 * time.Second
-
 	rc := fs.ReadyConfig()
-	rc.ScrapeIntervals = []time.Duration{interval}
+	rc.ScrapeIntervals = []time.Duration{79 * time.Second, 19 * time.Second}
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
 	defer cancel()

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -90,7 +90,7 @@ func TestReadySpecificInterval(t *testing.T) {
 	const interval = 79 * time.Second
 
 	rc := fs.ReadyConfig()
-	rc.LongestInterval = interval
+	rc.ScrapeIntervals = []time.Duration{time.Minute, interval}
 
 	go func() {
 		time.Sleep(1 * time.Second)
@@ -121,7 +121,7 @@ func TestReadySpecificIntervalWait(t *testing.T) {
 	const interval = 79 * time.Second
 
 	rc := fs.ReadyConfig()
-	rc.LongestInterval = interval
+	rc.ScrapeIntervals = []time.Duration{interval}
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
 	defer cancel()

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -70,7 +70,7 @@ func TestReader_Progress(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestReader_Progress(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
-	tailer, err = tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err = tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -82,9 +81,9 @@ type Tailer struct {
 	dir string
 	cur io.ReadCloser
 
-	logger  log.Logger
-	promURL *url.URL
-	monitor *prometheus.Monitor
+	logger   log.Logger
+	readyCfg config.PromReady
+	monitor  *prometheus.Monitor
 
 	mtx         sync.Mutex
 	nextSegment int
@@ -95,15 +94,15 @@ type Tailer struct {
 // are read before reading any WAL segments.
 // Tailing may fail if we are racing with the DB itself in deleting obsolete checkpoints
 // and segments. The caller should implement relevant logic to retry in those cases.
-func Tail(ctx context.Context, logger log.Logger, dir string, promURL *url.URL) (*Tailer, error) {
-	mu := *promURL
+func Tail(ctx context.Context, logger log.Logger, dir string, readyCfg config.PromReady) (*Tailer, error) {
+	mu := *readyCfg.PromURL
 	mu.Path = path.Join(mu.Path, "metrics")
 	t := &Tailer{
-		ctx:     ctx,
-		dir:     dir,
-		logger:  logger,
-		promURL: promURL,
-		monitor: prometheus.NewMonitor(&mu),
+		ctx:      ctx,
+		dir:      dir,
+		logger:   logger,
+		readyCfg: readyCfg,
+		monitor:  prometheus.NewMonitor(&mu),
 	}
 	cpdir, k, err := wal.LastCheckpoint(dir)
 	if errors.Cause(err) == record.ErrNotFound {
@@ -235,10 +234,7 @@ func (t *Tailer) CurrentSegment() int {
 
 func (t *Tailer) waitForReadiness() error {
 	// Note: no timeout on the context, we're really waiting.
-	return prometheus.WaitForReady(t.ctx, prometheus.ReadyConfig{
-		Logger:  t.logger,
-		PromURL: t.promURL,
-	})
+	return prometheus.WaitForReady(t.ctx, t.readyCfg)
 }
 
 func (t *Tailer) getPrometheusSegment() (int, error) {

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -235,7 +235,10 @@ func (t *Tailer) CurrentSegment() int {
 
 func (t *Tailer) waitForReadiness() error {
 	// Note: no timeout on the context, we're really waiting.
-	return prometheus.WaitForReady(t.ctx, t.logger, t.promURL)
+	return prometheus.WaitForReady(t.ctx, prometheus.ReadyConfig{
+		Logger:  t.logger,
+		PromURL: t.promURL,
+	})
 }
 
 func (t *Tailer) getPrometheusSegment() (int, error) {

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -68,7 +68,7 @@ func TestCorruption(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestInvalidSegment(t *testing.T) {
 	prom := promtest.NewFakePrometheus()
 	prom.SetSegment(2)
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestTailFuzz(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestSlowFsync(t *testing.T) {
 
 	w.Log(rec)
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This monitors the `prometheus_target_interval_length_seconds` metric to ensure Prometheus has finished its collection interval(s) before the sidecar begins running.

Fixes #119.
