### PR TITLE
Record corrupt segment, skip on next restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+- The sidecar's WAL reader could get stuck in a restart loop in the event
+  that the WAL's first segment after a checkpoint was truncated. The reader will
+  now record the `corrupt-segment` in the progress log and skip the recorded
+  segment on next restart (#136)
+
 ## [0.17.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.17.0) - 2021-02-23
 ### Added
 - Automatically set (the same) `service.instance.id` for Destination/Diagnostics

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -40,11 +41,11 @@ import (
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/tail"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/oklog/run"
-	"go.opentelemetry.io/otel/semconv"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"go.opentelemetry.io/otel/semconv"
 	grpcMetadata "google.golang.org/grpc/metadata"
 
 	// register grpc compressors
@@ -142,11 +143,19 @@ func Main() bool {
 	}
 	metadataCache := metadata.NewCache(httpClient, metadataURL, staticMetadata)
 
+	// Check the progress file, ensure we can write this file.
+	startOffset, corruptSegment, err := readWriteStartOffset(cfg, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "cannot write progress file", "err", err)
+		return false
+	}
+
 	tailer, err := tail.Tail(
 		ctx,
 		log.With(logger, "component", "wal_reader"),
 		cfg.Prometheus.WAL,
 		promURL,
+		corruptSegment,
 	)
 	if err != nil {
 		level.Error(logger).Log("msg", "tailing WAL failed", "err", err)
@@ -211,13 +220,6 @@ func Main() bool {
 		}
 	}()
 
-	// Check the progress file, ensure we can write this file.
-	startOffset, err := readWriteStartOffset(cfg, logger)
-	if err != nil {
-		level.Error(logger).Log("msg", "cannot write progress file", "err", err)
-		return false
-	}
-
 	logStartup(cfg, logger)
 
 	// Test for Prometheus and Outbound dependencies before starting.
@@ -246,7 +248,10 @@ func Main() bool {
 		g.Add(
 			func() error {
 				level.Info(logger).Log("msg", "starting Prometheus reader")
-				err = prometheusReader.Run(ctx, startOffset)
+				err = prometheusReader.Run(ctx, startOffset, corruptSegment)
+				if strings.Contains(err.Error(), "truncated WAL segment") {
+					_ = retrieval.SaveProgressFile(cfg.Prometheus.WAL, startOffset, tailer.CurrentSegment())
+				}
 				return err
 			},
 			func(err error) {
@@ -395,13 +400,13 @@ func newAdminServer(hc *health.Checker, acfg config.AdminConfig, logger log.Logg
 
 // readWriteStartOffset reads the last (approxiate) progress position and re-writes
 // the progress file, to ensure we have write permission on startup.
-func readWriteStartOffset(cfg config.MainConfig, logger log.Logger) (int, error) {
-	startOffset, err := retrieval.ReadProgressFile(cfg.Prometheus.WAL)
+func readWriteStartOffset(cfg config.MainConfig, logger log.Logger) (int, int, error) {
+	startOffset, corruptSegment, err := retrieval.ReadProgressFile(cfg.Prometheus.WAL)
 	if err != nil {
 		level.Warn(logger).Log("msg", "reading progress file failed", "err", err)
 		startOffset = 0
 	}
 
-	err = retrieval.SaveProgressFile(cfg.Prometheus.WAL, startOffset)
-	return startOffset, err
+	err = retrieval.SaveProgressFile(cfg.Prometheus.WAL, startOffset, corruptSegment)
+	return startOffset, corruptSegment, err
 }

--- a/otlp/queue_manager_test.go
+++ b/otlp/queue_manager_test.go
@@ -225,7 +225,7 @@ func TestSampleDeliverySimple(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestSampleDeliveryMultiShard(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(context.Background(), telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -96,7 +96,7 @@ type PrometheusReader struct {
 	extraLabels          labels.Labels
 }
 
-func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
+func (r *PrometheusReader) Run(ctx context.Context, startOffset int, corruptSegment int) error {
 	level.Info(r.logger).Log("msg", "starting Prometheus reader")
 
 	seriesCache := newSeriesCache(
@@ -134,7 +134,7 @@ Outer:
 		rec := reader.Record()
 
 		if offset > startOffset && time.Since(lastSave) > r.progressSaveInterval {
-			if err := SaveProgressFile(r.walDirectory, offset); err != nil {
+			if err := SaveProgressFile(r.walDirectory, offset, corruptSegment); err != nil {
 				level.Error(r.logger).Log("msg", "saving progress failed", "err", err)
 			} else {
 				lastSave = time.Now()
@@ -236,30 +236,32 @@ const (
 type progress struct {
 	// Approximate WAL offset of last synchronized records in bytes.
 	Offset int `json:"offset"`
+	//
+	CorruptSegment int `json:"corrupt-segment"`
 }
 
-// ReadPRogressFile reads the progress file in the given directory and returns
+// ReadProgressFile reads the progress file in the given directory and returns
 // the saved offset.
-func ReadProgressFile(dir string) (offset int, err error) {
+func ReadProgressFile(dir string) (offset int, corruptSegment int, err error) {
 	b, err := ioutil.ReadFile(filepath.Join(dir, progressFilename))
 	if os.IsNotExist(err) {
-		return 0, nil
+		return 0, -1, nil
 	}
 	if err != nil {
-		return 0, err
+		return 0, -1, err
 	}
 	var p progress
 	if err := json.Unmarshal(b, &p); err != nil {
-		return 0, err
+		return 0, -1, err
 	}
-	return p.Offset, nil
+	return p.Offset, p.CorruptSegment, nil
 }
 
 // SaveProgressFile saves a progress file with the given offset in directory.
-func SaveProgressFile(dir string, offset int) error {
+func SaveProgressFile(dir string, offset int, corruptSegment int) error {
 	// Adjust offset to account for buffered records that possibly haven't been
 	// written yet.
-	b, err := json.Marshal(progress{Offset: offset - progressBufferMargin})
+	b, err := json.Marshal(progress{Offset: offset - progressBufferMargin, CorruptSegment: corruptSegment})
 	if err != nil {
 		return err
 	}

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -70,7 +70,7 @@ func TestReader_Progress(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	tailer, err := tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err := tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,9 +134,9 @@ func TestReader_Progress(t *testing.T) {
 		}
 	}()
 	// Proess the WAL until the writing goroutine completes.
-	r.Run(ctx, 0)
+	r.Run(ctx, 0, -1)
 
-	progressOffset, err := ReadProgressFile(dir)
+	progressOffset, _, err := ReadProgressFile(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,14 +153,14 @@ func TestReader_Progress(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
-	tailer, err = tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	tailer, err = tail.Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	recorder := &nopAppender{}
 	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, extraLabels)
-	go r.Run(ctx, progressOffset)
+	go r.Run(ctx, progressOffset, -1)
 
 	// Wait for reader to process until the end.
 	ctx, _ = context.WithTimeout(ctx, 5*time.Second)
@@ -210,22 +210,28 @@ func TestReader_ProgressFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	offset, err := ReadProgressFile(dir)
+	offset, corruptSegment, err := ReadProgressFile(dir)
 	if err != nil {
 		t.Fatalf("read progress: %s", err)
 	}
 	if offset != 0 {
 		t.Fatalf("expected offset %d but got %d", 0, offset)
 	}
-	if err := SaveProgressFile(dir, progressBufferMargin+12345); err != nil {
+	if corruptSegment != -1 {
+		t.Fatalf("expected corrupt-segment %d but got %d", -1, corruptSegment)
+	}
+	if err := SaveProgressFile(dir, progressBufferMargin+12345, 10); err != nil {
 		t.Fatalf("save progress: %s", err)
 	}
-	offset, err = ReadProgressFile(dir)
+	offset, corruptSegment, err = ReadProgressFile(dir)
 	if err != nil {
 		t.Fatalf("read progress: %s", err)
 	}
 	if offset != 12345 {
 		t.Fatalf("expected progress offset %d but got %d", 12345, offset)
+	}
+	if corruptSegment != 9 {
+		t.Fatalf("expected corrupt-segment %d but got %d", 9, corruptSegment)
 	}
 }
 

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -230,7 +230,7 @@ func TestReader_ProgressFile(t *testing.T) {
 	if offset != 12345 {
 		t.Fatalf("expected progress offset %d but got %d", 12345, offset)
 	}
-	if corruptSegment != 9 {
+	if corruptSegment != 10 {
 		t.Fatalf("expected corrupt-segment %d but got %d", 9, corruptSegment)
 	}
 }

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -127,7 +127,7 @@ func Tail(ctx context.Context, logger log.Logger, dir string, promURL *url.URL, 
 		}
 		// We will resume reading ordinary segments at k+1.
 		k += 1
-		if k == corruptSegment-1 {
+		if k == corruptSegment {
 			// check if k is known as corrupt
 			// if so, skip it
 			level.Warn(t.logger).Log(
@@ -136,7 +136,7 @@ func Tail(ctx context.Context, logger log.Logger, dir string, promURL *url.URL, 
 			)
 			k += 1
 		}
-		t.nextSegment = k + 1
+		t.nextSegment = k
 	}
 	return t, nil
 }

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -88,8 +88,6 @@ type Tailer struct {
 	mtx         sync.Mutex
 	nextSegment int
 	offset      int // Bytes read within the current reader.
-
-	corruptSegment int
 }
 
 // Tail the prometheus/tsdb write ahead log in the given directory. Checkpoints
@@ -409,7 +407,6 @@ func (t *Tailer) Read(b []byte) (int, error) {
 					"offset", currentOffset,
 				)
 			})
-			t.corruptSegment = t.CurrentSegment()
 			return 0, errors.Errorf(
 				"truncated WAL segment %d @ %d",
 				currentSegment,

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -193,10 +193,6 @@ func (t *Tailer) incOffset(v int) {
 	t.offset += v
 }
 
-func (t *Tailer) CurrentOffset() int {
-	return t.currentOffset()
-}
-
 func (t *Tailer) currentOffset() int {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -68,7 +68,7 @@ func TestCorruption(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestInvalidSegment(t *testing.T) {
 	prom := promtest.NewFakePrometheus()
 	prom.SetSegment(2)
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestTailFuzz(t *testing.T) {
 
 	prom := promtest.NewFakePrometheus()
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestSlowFsync(t *testing.T) {
 
 	w.Log(rec)
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -334,7 +334,7 @@ func TestCorruptSegment(t *testing.T) {
 
 	w.Log(rec)
 
-	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.URL, 4044)
+	rc, err := Tail(ctx, telemetry.DefaultLogger(), dir, prom.ReadyConfig(), 4044)
 	require.Nil(t, err)
 	require.Equal(t, 4045, rc.nextSegment)
 }


### PR DESCRIPTION
In the unlikely event of a corrupt WAL segment, this PR records the corrupt segment in the progress file and lets the sidecar exit as it did before.

This also changes the behaviour of the sidecar to read the corrupted segment value from the progress file, and skip it on start.