### PR TITLE
set max shards to 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ### Changed
-- Reduce the default value for max shards to 200. ()
+- Reduce the default value for max shards to 200. (#139)
+
 ## [0.18.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.18.0) - 2021-02-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+- Reduce the default value for max shards to 200. ()
 ## [0.18.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.18.0) - 2021-02-26
 
 ### Added

--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ const (
 	// How many points per request
 	DefaultMaxTimeseriesPerRequest = 2000
 	// Max number of shards, i.e. amount of concurrency
-	DefaultMaxShards = 2000
+	DefaultMaxShards = 200
 
 	// TODO: The setting below is not configurable, it should be.
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,7 +174,7 @@ startup_timeout: 1777s
 						25 * time.Hour,
 					},
 					MaxTimeseriesPerRequest: 2000,
-					MaxShards:               2000,
+					MaxShards:               200,
 					ScrapeIntervals: []string{
 						(1333 * time.Second).String(),
 					},

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -42,7 +42,7 @@ func Example() {
 	//     "wal": "/volume/wal",
 	//     "max_point_age": "72h0m0s",
 	//     "max_timeseries_per_request": 2000,
-	//     "max_shards": 2000,
+	//     "max_shards": 200,
 	//     "scrape_intervals": [
 	//       "30s",
 	//       "60s"

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -39,7 +39,7 @@ prometheus:
   max_timeseries_per_request: 2000
 
   # Max number of shards, i.e. amount of concurrency
-  max_shards: 2000
+  max_shards: 200
 
   # Scrape intervals, when set, are used to delay startup.  If set, 
   # the sidecar will wait until the first scrape completes with


### PR DESCRIPTION
The previous value of 2000 can require a large memory footprint, therefore it's best to keep the default more conservative.