### PR TITLE
check minimum version of prometheus on startup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,8 @@ jobs:
         cd $HOME/prom/
         wget https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz
         tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
-        cp prometheus-${PROM_VERSION}.linux-amd64/prom* /usr/local/bin/
+        mkdir -p $GITHUB_WORKSPACE/bin
+        cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
 
     - name: Build
       run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
         mkdir -p $GITHUB_WORKSPACE/bin
         cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
     - name: Build
       run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
         mkdir -p $GITHUB_WORKSPACE/bin
         cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
+        echo "::add-path::$GITHUB_WORKSPACE/bin"
 
     - name: Build
       run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
         
     - name: Install Prometheus
       run: |
+        export PROM_VERSION=`cat $GITHUB_WORKSPACE/PROM_VERSION`
         mkdir $HOME/prom
-        cd $HOME/prom
-        git clone https://github.com/prometheus/prometheus.git
-        cd $HOME/prom/prometheus
-        git checkout v`cat $GITHUB_WORKSPACE/PROM_VERSION`
-        go install ./cmd/prometheus
+        cd $HOME/prom/
+        wget https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz
+        tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
+        cp prometheus-${PROM_VERSION}.linux-amd64/prom* /usr/local/bin/
 
     - name: Build
       run: make

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,17 +15,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
-        
-    - name: Install Prometheus
-      run: |
-        export PROM_VERSION=`cat $GITHUB_WORKSPACE/PROM_VERSION`
-        mkdir $HOME/prom
-        cd $HOME/prom/
-        wget https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz
-        tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
-        mkdir -p $GITHUB_WORKSPACE/bin
-        cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
 
     - name: Build
       run: make build-linux-amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
         
     - name: Install Prometheus
       run: |
+        export PROM_VERSION=`cat $GITHUB_WORKSPACE/PROM_VERSION`
         mkdir $HOME/prom
-        cd $HOME/prom
-        git clone https://github.com/prometheus/prometheus.git
-        cd $HOME/prom/prometheus
-        git checkout v`cat $GITHUB_WORKSPACE/PROM_VERSION`
-        go install ./cmd/prometheus
+        cd $HOME/prom/
+        wget https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz
+        tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
+        cp prometheus-${PROM_VERSION}.linux-amd64/prom* /usr/local/bin/
 
     - name: Build
       run: make build-linux-amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
         mkdir -p $GITHUB_WORKSPACE/bin
         cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
+        echo "::add-path::$GITHUB_WORKSPACE/bin"
 
     - name: Build
       run: make build-linux-amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,8 @@ jobs:
         cd $HOME/prom/
         wget https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz
         tar -xvzf prometheus-${PROM_VERSION}.linux-amd64.tar.gz
-        cp prometheus-${PROM_VERSION}.linux-amd64/prom* /usr/local/bin/
+        mkdir -p $GITHUB_WORKSPACE/bin
+        cp prometheus-${PROM_VERSION}.linux-amd64/prom* $GITHUB_WORKSPACE/bin
 
     - name: Build
       run: make build-linux-amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+- Fix issue that caused a segmentation failure on clean exit (#143)
+
+### Added
+- Added a check for minimum version of prometheus on start, report an error and exit if prometheus running
+  is less version 2.10.0 (#144)
+
 ## [0.18.2](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.18.2) - 2021-02-26
 
 ### Changed

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -336,9 +336,9 @@ func selfTest(ctx context.Context, scf otlp.StorageClientFactory, timeout time.D
 	level.Debug(logger).Log("msg", "checking Prometheus readiness")
 
 	// These tests are performed sequentially, to keep the logs simple.
-	// Note waitForPrometheus has no unrecoverable error conditions, so
-	// loops until success or the context is canceled.
-	if err := prometheus.WaitForReady(ctx, readyCfg); err != nil {
+	// Note WaitForReady loops until success or stop if the context is canceled
+	// or an unsupported version of prometheus is identified
+	if err := prometheus.WaitForReady(ctx, cancel, readyCfg); err != nil {
 		return errors.Wrap(err, "Prometheus is not ready")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,11 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 	// PrometheusTargetIntervalLengthName is an internal histogram
 	// indicating how long the interval between scrapes.
 	PrometheusTargetIntervalLengthName = "prometheus_target_interval_length_seconds"
+
+	// PrometheusBuildInfoName provides prometheus version information
+	PrometheusBuildInfoName = "prometheus_build_info"
+	// PromethuesMinVersion is the minimum supported version
+	PromethuesMinVersion = "2.10.0"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/snappy v0.0.2
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.1.2
+	github.com/hashicorp/go-version v1.2.0
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,7 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/prometheus/monitor.go
+++ b/prometheus/monitor.go
@@ -195,3 +195,22 @@ func (s Summary) Count() uint64 {
 	}
 	return *s.summary.SampleCount
 }
+
+// AllLabels returns the set of labels present for this family
+func (f Family) AllLabels() []labels.Labels {
+	if f.family == nil {
+		return nil
+	}
+	var res []labels.Labels
+	for _, m := range f.family.Metric {
+		var ll labels.Labels
+		for _, lp := range m.Label {
+			ll = append(ll, labels.Label{
+				Name:  *lp.Name,
+				Value: *lp.Value,
+			})
+		}
+		res = append(res, ll)
+	}
+	return res
+}

--- a/prometheus/ready.go
+++ b/prometheus/ready.go
@@ -16,7 +16,7 @@ const (
 	scrapeIntervalName = config.PrometheusTargetIntervalLengthName
 )
 
-func checkPrometheusVersion(inCtx context.Context, cfg config.PromReady) error {
+func scrapeMetrics(inCtx context.Context, cfg config.PromReady) (Result, error) {
 	u := *cfg.PromURL
 	u.Path = path.Join(u.Path, "/metrics")
 
@@ -24,14 +24,13 @@ func checkPrometheusVersion(inCtx context.Context, cfg config.PromReady) error {
 	defer cancel()
 
 	mon := NewMonitor(&u)
-	res, err := mon.Get(ctx)
-	if err != nil {
-		return err
-	}
+	return mon.Get(ctx)
+}
 
+func checkPrometheusVersion(res Result) error {
 	minVersion, _ := goversion.NewVersion(config.PromethuesMinVersion)
 	var prometheusVersion *goversion.Version
-	err = errors.New("version not found")
+	err := errors.New("version not found")
 	for _, lp := range res.Gauge(config.PrometheusBuildInfoName).AllLabels() {
 		if len(lp.Get("version")) > 0 {
 			prometheusVersion, err = goversion.NewVersion(lp.Get("version"))
@@ -49,18 +48,8 @@ func checkPrometheusVersion(inCtx context.Context, cfg config.PromReady) error {
 	return nil
 }
 
-func completedFirstScrapes(inCtx context.Context, cfg config.PromReady) error {
-	u := *cfg.PromURL
-	u.Path = path.Join(u.Path, "/metrics")
+func completedFirstScrapes(res Result, cfg config.PromReady) error {
 
-	ctx, cancel := context.WithTimeout(inCtx, config.DefaultHealthCheckTimeout)
-	defer cancel()
-
-	mon := NewMonitor(&u)
-	res, err := mon.Get(ctx)
-	if err != nil {
-		return err
-	}
 	summary := res.Summary(scrapeIntervalName)
 	foundLabelSets := summary.AllLabels()
 	if len(foundLabelSets) == 0 {
@@ -109,7 +98,7 @@ func completedFirstScrapes(inCtx context.Context, cfg config.PromReady) error {
 	return nil
 }
 
-func WaitForReady(inCtx context.Context, cfg config.PromReady) error {
+func WaitForReady(inCtx context.Context, inCtxCancel context.CancelFunc, cfg config.PromReady) error {
 	u := *cfg.PromURL
 	u.Path = path.Join(u.Path, "/-/ready")
 
@@ -128,12 +117,6 @@ func WaitForReady(inCtx context.Context, cfg config.PromReady) error {
 			return errors.Wrap(err, "build request")
 		}
 
-		err = checkPrometheusVersion(inCtx, cfg)
-		if err != nil {
-			cancel()
-			return err
-		}
-
 		success := func() bool {
 			defer cancel()
 			resp, err := http.DefaultClient.Do(req)
@@ -145,9 +128,21 @@ func WaitForReady(inCtx context.Context, cfg config.PromReady) error {
 			respOK := err == nil && resp.StatusCode/100 == 2
 
 			if respOK {
+				result, err := scrapeMetrics(inCtx, cfg)
+				if err != nil {
+					return false
+				}
+				err = checkPrometheusVersion(result)
+				if err != nil {
+					// invalid prometheus version is unrecoverable
+					// cancel the caller's context and exit
+					level.Warn(cfg.Logger).Log("msg", "Invalid Prometheus version", "err", err)
+					inCtxCancel()
+					return false
+				}
 				// Great! We also need it to have completed
 				// a full round of scrapes.
-				err = completedFirstScrapes(inCtx, cfg)
+				err = completedFirstScrapes(result, cfg)
 				if err == nil {
 					return true
 				}

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -22,6 +22,14 @@ func TestReady(t *testing.T) {
 	require.NoError(t, WaitForReady(context.Background(), fs.ReadyConfig()))
 }
 
+func TestInvalidVersion(t *testing.T) {
+	fs := promtest.NewFakePrometheusWithVersion("2.1.0")
+
+	err := WaitForReady(context.Background(), fs.ReadyConfig())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "prometheus version")
+}
+
 func TestSlowStart(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -18,16 +18,20 @@ func TestReady(t *testing.T) {
 	fs := promtest.NewFakePrometheus()
 	fs.SetReady(true)
 	fs.SetIntervals(30 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
+	defer cancel()
 
-	require.NoError(t, WaitForReady(context.Background(), fs.ReadyConfig()))
+	require.NoError(t, WaitForReady(ctx, cancel, fs.ReadyConfig()))
 }
 
 func TestInvalidVersion(t *testing.T) {
 	fs := promtest.NewFakePrometheusWithVersion("2.1.0")
 
-	err := WaitForReady(context.Background(), fs.ReadyConfig())
+	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
+	defer cancel()
+	err := WaitForReady(ctx, cancel, fs.ReadyConfig())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "prometheus version")
+	require.Equal(t, context.Canceled, err)
 }
 
 func TestSlowStart(t *testing.T) {
@@ -42,8 +46,9 @@ func TestSlowStart(t *testing.T) {
 		time.Sleep(time.Second * 3)
 		fs.SetIntervals(30)
 	}()
-
-	require.NoError(t, WaitForReady(context.Background(), fs.ReadyConfig()))
+	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
+	defer cancel()
+	require.NoError(t, WaitForReady(ctx, cancel, fs.ReadyConfig()))
 }
 
 func TestNotReady(t *testing.T) {
@@ -55,7 +60,7 @@ func TestNotReady(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*config.DefaultHealthCheckTimeout)
 	defer cancel()
-	err := WaitForReady(ctx, fs.ReadyConfig())
+	err := WaitForReady(ctx, cancel, fs.ReadyConfig())
 	require.Error(t, err)
 	require.Equal(t, context.DeadlineExceeded, err)
 }
@@ -70,7 +75,7 @@ func TestReadyFail(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*config.DefaultHealthCheckTimeout)
 	defer cancel()
-	err = WaitForReady(ctx, config.PromReady{
+	err = WaitForReady(ctx, cancel, config.PromReady{
 		Logger:  logger,
 		PromURL: tu,
 	})
@@ -82,7 +87,7 @@ func TestReadyCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediate
-	err := WaitForReady(ctx, fs.ReadyConfig())
+	err := WaitForReady(ctx, cancel, fs.ReadyConfig())
 
 	require.Error(t, err)
 	require.Equal(t, context.Canceled, err)
@@ -113,8 +118,8 @@ func TestReadySpecificInterval(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		fs.SetIntervals(20*time.Second, 40*time.Second, 60*time.Second, interval)
 	}()
-
-	err := WaitForReady(context.Background(), rc)
+	ctx, cancel := context.WithCancel(context.Background())
+	err := WaitForReady(ctx, cancel, rc)
 
 	require.NoError(t, err)
 }
@@ -131,7 +136,7 @@ func TestReadySpecificIntervalWait(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultHealthCheckTimeout*4/3)
 	defer cancel()
-	err := WaitForReady(ctx, rc)
+	err := WaitForReady(ctx, cancel, rc)
 
 	require.Error(t, err)
 	require.Equal(t, context.DeadlineExceeded, err)

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -244,7 +244,8 @@ func (t *Tailer) CurrentSegment() int {
 
 func (t *Tailer) waitForReadiness() error {
 	// Note: no timeout on the context, we're really waiting.
-	return prometheus.WaitForReady(t.ctx, t.readyCfg)
+	ctx, cancel := context.WithCancel(t.ctx)
+	return prometheus.WaitForReady(ctx, cancel, t.readyCfg)
 }
 
 func (t *Tailer) getPrometheusSegment() (int, error) {


### PR DESCRIPTION
This change uses the `/metrics` endpoint to get the `prometheus_build_info` data from prometheus and extract the prometheus version number. If the version is below `2.10.0`, the sidecar exits.

A follow up PR will report this data in the tracing information emitted by the sidecar