### PR TITLE
Use previous value for cumulative resets

### DIFF
--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -98,9 +98,21 @@ type seriesCacheEntry struct {
 	suffix   string
 	hash     uint64
 
-	hasReset       bool
+	// Whether the series has been reset/initialized yet. This is false only for
+	// the first sample of a new series in the cache, which causes the initial
+	// "reset". After that, it is always true.
+	hasReset bool
+
+	// The value and timestamp of the latest reset. The timestamp is when it
+	// occurred, and the value is what it was reset to. resetValue will initially
+	// be the value of the first sample, and then 0 for every subsequent reset.
 	resetValue     float64
 	resetTimestamp int64
+
+	// Value of the most recent point seen for the time series. If a new value is
+	// less than the previous, then the series has reset.
+	previousValue float64
+
 	// maxSegment indicates the maximum WAL segment index in which
 	// the series was first logged.
 	// By providing it as an upper bound, we can safely delete a series entry
@@ -281,24 +293,22 @@ func (c *seriesCache) getResetAdjusted(ref uint64, t int64, v float64) (int64, f
 	if !hasReset {
 		e.resetTimestamp = t
 		e.resetValue = v
+		e.previousValue = v
 		// If we just initialized the reset timestamp, this sample should be skipped.
 		// We don't know the window over which the current cumulative value was built up over.
 		// The next sample for will be considered from this point onwards.
 		return 0, 0, false
 	}
-	if v < e.resetValue {
+	if v < e.previousValue {
+		// If the value has dropped, there's been a reset.
 		// If the series was reset, set the reset timestamp to be one millisecond
 		// before the timestamp of the current sample.
 		// We don't know the true reset time but this ensures the range is non-zero
 		// while unlikely to conflict with any previous sample.
 		e.resetValue = 0
 		e.resetTimestamp = t - 1
-	} else if e.resetTimestamp >= t {
-		// TODO: This case is problematic and typically
-		// results in some kind of data validation error.  An
-		// out-of-order WAL entry?
-		// https://github.com/lightstep/opentelemetry-prometheus-sidecar/issues/84
 	}
+	e.previousValue = v
 	return e.resetTimestamp, v - e.resetValue, true
 }
 


### PR DESCRIPTION
Follows the issue fixed upstream https://github.com/Stackdriver/stackdriver-prometheus-sidecar/pull/263.

This appears to allow the reset timestamp to be too old--once it resets to zero once, it'll never reset again. This fix ensures that the reset timestamp adjusts when the value falls.