### PR TITLE
add healthcheck threshold ratio config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+- Adding `--healthcheck.threshold-ratio` to support tuning the acceptable error ratio
+  when exporting metrics to a backend. (#146)
 
 ## [0.18.3](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.18.3) - 2021-03-04
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Flags:
                                  Period for internal health checking; set at a
                                  minimum to the shortest Promethues scrape
                                  period
+      --healthcheck.threshold-ratio=HEALTHCHECK.THRESHOLD-RATIO
+                                 Threshold ratio for internal health checking.
+                                 Default: 0.5
       --log.level=LOG.LEVEL      Only log messages with the given severity or
                                  above. One of: [debug, info, warn, error]
       --log.format=LOG.FORMAT    Output format of log messages. One of: [logfmt,

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -120,7 +120,7 @@ func Main() bool {
 	defer cancelMain()
 
 	healthChecker := health.NewChecker(
-		telem.Controller, cfg.Admin.HealthCheckPeriod.Duration, logger,
+		telem.Controller, cfg.Admin.HealthCheckPeriod.Duration, logger, cfg.Admin.HealthCheckThresholdRatio,
 	)
 
 	httpClient := &http.Client{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -180,9 +180,10 @@ startup_timeout: 1777s
 					},
 				},
 				Admin: AdminConfig{
-					ListenIP:          config.DefaultAdminListenIP,
-					Port:              config.DefaultAdminPort,
-					HealthCheckPeriod: DurationConfig{config.DefaultHealthCheckPeriod},
+					ListenIP:                  config.DefaultAdminListenIP,
+					Port:                      config.DefaultAdminPort,
+					HealthCheckPeriod:         DurationConfig{config.DefaultHealthCheckPeriod},
+					HealthCheckThresholdRatio: config.DefaultHealthCheckThresholdRatio,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "http://womp.womp",
@@ -272,6 +273,7 @@ log:
 				"--prometheus.scrape-interval=22m13s",
 				"--log.level=warning",
 				"--healthcheck.period=17s",
+				"--healthcheck.threshold-ratio=0.2",
 				"--diagnostics.endpoint", "https://look.here",
 				"--disable-diagnostics",
 				`--filter=l1{l2="v3"}`,
@@ -291,9 +293,10 @@ log:
 					},
 				},
 				Admin: AdminConfig{
-					ListenIP:          config.DefaultAdminListenIP,
-					Port:              config.DefaultAdminPort,
-					HealthCheckPeriod: DurationConfig{17 * time.Second},
+					ListenIP:                  config.DefaultAdminListenIP,
+					Port:                      config.DefaultAdminPort,
+					HealthCheckPeriod:         DurationConfig{17 * time.Second},
+					HealthCheckThresholdRatio: 0.2,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "http://womp.womp",
@@ -376,6 +379,7 @@ admin:
   listen_ip: 0.0.0.0
   port: 9999
   health_check_period: 10s
+  health_check_threshold_ratio: 0.1
 
 security:
   root_certificates:
@@ -411,9 +415,10 @@ static_metadata:
 					},
 				},
 				Admin: AdminConfig{
-					ListenIP:          config.DefaultAdminListenIP,
-					Port:              9999,
-					HealthCheckPeriod: DurationConfig{10 * time.Second},
+					ListenIP:                  config.DefaultAdminListenIP,
+					Port:                      9999,
+					HealthCheckPeriod:         DurationConfig{10 * time.Second},
+					HealthCheckThresholdRatio: 0.1,
 				},
 				StartupTimeout: DurationConfig{
 					33 * time.Second,

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -54,7 +54,8 @@ func Example() {
 	//   "admin": {
 	//     "listen_ip": "0.0.0.0",
 	//     "port": 10000,
-	//     "health_check_period": "20s"
+	//     "health_check_period": "20s",
+	//     "health_check_threshold_ratio": 0.5
 	//   },
 	//   "security": {
 	//     "root_certificates": [

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -61,6 +61,10 @@ admin:
   # be raised for Prometheus configurations that scrape infrequently.
   # Default: 1m
   health_check_period: 20s
+  # Controls the threshold ratio used to determine if the check
+  # should pass or fail based on the number of succes or failure to
+  # send metrics via OTLP
+  health_check_threshold_ratio: 0.5
 
 # Security settings:
 security:


### PR DESCRIPTION
If users encounter problems with sending metrics to their
backend, tuning the threshold ratio can help ensure the
sidecar's healthcheck doesn't fail.

Before this change, the threshold was hard coded to 0.5, which
remains the default if unset.