### PR TITLE
Histogram metadata missing bugfix

### DIFF
--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/tsdb/wal"
 	"go.opentelemetry.io/otel/semconv"
 	grpcMetadata "google.golang.org/grpc/metadata"
 
@@ -251,7 +252,7 @@ func Main() bool {
 	{
 		g.Add(
 			func() error {
-				level.Info(logger).Log("msg", "starting Prometheus reader")
+				level.Info(logger).Log("msg", "starting Prometheus reader", "segment", startOffset/wal.DefaultSegmentSize)
 				err = prometheusReader.Run(ctx, startOffset, corruptSegment)
 				if err != nil && strings.Contains(err.Error(), "truncated WAL segment") {
 					_ = retrieval.SaveProgressFile(cfg.Prometheus.WAL, startOffset, tailer.CurrentSegment())

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -188,10 +188,9 @@ Outer:
 				outputSample, hash, newSamples, err := builder.next(ctx, samples)
 
 				if len(samples) == len(newSamples) {
-					// Note: This means builder.next() has a bug, but is
-					// easy to mitigate.  There are a few code paths where
-					// it's easier to fall through to this than to be sure
-					// the samples list becomes shorter by at least 1.
+					// Note: There are a few code paths in `builder.next()`
+					// where it's easier to fall through to this than to be
+					// sure the samples list becomes shorter by at least 1.
 					samples = samples[1:]
 				} else {
 					samples = newSamples

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -152,10 +152,6 @@ Outer:
 			for _, s := range series {
 				err = seriesCache.set(ctx, s.Ref, s.Labels, r.tailer.CurrentSegment())
 				if err != nil {
-					// TODO: This code path deserves the same kind of
-					// backoff used in the record.Samples branch.
-					// We'll hit Prometheus quite hard if the target
-					// cache refresh is failing.
 					doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
 						level.Error(r.logger).Log(
 							"msg", "update series cache",
@@ -180,7 +176,6 @@ Outer:
 				level.Error(r.logger).Log("decode samples", "err", err)
 				continue
 			}
-			backoff := time.Duration(0)
 			processed, produced := len(samples), 0
 
 			for len(samples) > 0 {
@@ -189,22 +184,30 @@ Outer:
 					break Outer
 				default:
 				}
-				// We intentionally don't use time.After in the select statement above
-				// since we'd unnecessarily spawn a new goroutine for each sample
-				// we process even when there are no errors.
-				if backoff > 0 {
-					time.Sleep(backoff)
-				}
 
 				outputSample, hash, newSamples, err := builder.next(ctx, samples)
-				samples = newSamples
+
+				if len(samples) == len(newSamples) {
+					// Note: This means builder.next() has a bug, but is
+					// easy to mitigate.
+					doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
+						level.Debug(r.logger).Log("msg", "internal error: next did not advance")
+					})
+					samples = samples[1:]
+				} else {
+					samples = newSamples
+				}
 				if err != nil {
-					level.Warn(r.logger).Log("msg", "failed to build sample", "err", err)
-					backoff = exponential(backoff)
+					// Note: This case is poorly monitored (LS-22396):
+					doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
+						level.Warn(r.logger).Log("msg", "failed to build sample", "err", err)
+					})
 					continue
 				}
 				if outputSample == nil {
-					// Note: This case is poorly monitored (LS-22396)
+					// Note: This case is poorly monitored (LS-22396): some of these
+					// cases are timestamp resets, which are ordinary, but can't be
+					// monitored either.
 					continue
 				}
 				r.appender.Append(ctx, hash, outputSample)

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -189,10 +189,9 @@ Outer:
 
 				if len(samples) == len(newSamples) {
 					// Note: This means builder.next() has a bug, but is
-					// easy to mitigate.
-					doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
-						level.Debug(r.logger).Log("msg", "internal error: next did not advance")
-					})
+					// easy to mitigate.  There are a few code paths where
+					// it's easier to fall through to this than to be sure
+					// the samples list becomes shorter by at least 1.
 					samples = samples[1:]
 				} else {
 					samples = newSamples

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -328,6 +328,12 @@ Loop:
 	for i, s := range samples {
 		e, ok, err := b.series.get(ctx, s.Ref)
 		if err != nil {
+			// Note: This case may or may not trigger the
+			// len(samples) == len(newSamples) test in
+			// manager.go. The important part here is that
+			// we may skip or may not skip any points that
+			// belong to the histogram, but if we don't
+			// the manager safetly advances.
 			return nil, 0, samples, err
 		}
 		if !ok {

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -38,6 +38,10 @@ const (
 	otlpCUMULATIVE = metric_pb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
 )
 
+var (
+	ErrHistogramMetadataMissing = errors.New("histogram metadata missing")
+)
+
 // Appender appends a time series with exactly one data point. A hash for the series
 // (but not the data point) must be provided.
 // The client may cache the computed hash more easily, which is why its part of the call
@@ -69,8 +73,9 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 	}
 
 	entry, ok, err := b.series.get(ctx, sample.Ref)
+
 	if err != nil {
-		return nil, 0, samples, errors.Wrap(err, "get series information")
+		return nil, 0, tailSamples, errors.Wrap(err, "get series information")
 	}
 	if !ok {
 		return nil, 0, tailSamples, nil
@@ -175,7 +180,7 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 		}
 
 	default:
-		return nil, 0, samples[1:], errors.Errorf("unexpected metric type %s", entry.metadata.MetricType)
+		return nil, 0, tailSamples, errors.Errorf("unexpected metric type %s", entry.metadata.MetricType)
 	}
 
 	if !b.series.updateSampleInterval(entry.hash, resetTimestamp, sample.T) {
@@ -382,6 +387,11 @@ Loop:
 		// TODO add a counter for this event. Note there is
 		// more validation we could do: the sum should agree
 		// with the buckets.
+		if consumed == 0 {
+			// This may be caused by a change of metadata or metadata conflict.
+			// There was no "le" label, or there was no _sum or _count suffix.
+			return nil, 0, samples[1:], ErrHistogramMetadataMissing
+		}
 		return nil, 0, samples[consumed:], nil
 	}
 	// We do not assume that the buckets in the sample batch are in order, so we sort them again here.

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -811,6 +811,20 @@ func TestSampleBuilder(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "gauge not histogram",
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1"),
+			},
+			resourceLabels: labels.FromStrings("resource_a", "abc"),
+			metadata: metadataMap{
+				"job1/instance1/metric1": &metadata.Entry{Metric: "metric1", MetricType: textparse.MetricTypeHistogram, ValueType: metadata.DOUBLE},
+			},
+			input: []record.RefSample{
+				{Ref: 1, T: 2000, V: 5.5},
+			},
+			fail: true,
+		},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
This ensures that the transform `builder.next()` always advances. There was a known case where a metric identified as histogram would see points that did not match, causing an infinite loop. This adds a bit of new logging as well, and removes a legacy backoff in the same area of the code, that was related to the old targets cache.

Fixes #150. 