### PR TITLE
Fix an unsupported value type error message

### DIFF
--- a/otlp/client.go
+++ b/otlp/client.go
@@ -350,7 +350,7 @@ func (c *Client) parseResponseMetadata(ctx context.Context, md grpcMetadata.MD) 
 				level.Info(c.logger).Log(
 					"msg", "unrecognized trailer",
 					"key", key,
-					"values", values,
+					"values", fmt.Sprint(values),
 				)
 			})
 		}


### PR DESCRIPTION
Replaces "unsupported value type" with the actual message in one location.