### PR TITLE
Always print the configuration at startup LS-23008

### DIFF
--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -389,7 +389,7 @@ func logStartup(cfg config.MainConfig, logger log.Logger) {
 	)
 
 	if data, err := json.Marshal(cfg); err == nil {
-		level.Debug(logger).Log("config", string(data))
+		level.Info(logger).Log("config", string(data))
 	}
 
 	if !cfg.DisableSupervisor {


### PR DESCRIPTION
The configuration is missing from the logs when not using debug-level logging. It helps to know unconditionally.