### PR TITLE
Raise the startup timeout to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Uses Prometheus `/api/v1/status/config` endpoint to read the Prometheus 
   config, to automatically determine the full set of scrape intervals. (#162)
+- The startup timeout is raised to 10 minutes. (#166)
 
 ### Removed
 - The `--prometheus.scrape-interval` option is ignored. (#162)

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ const (
 	DefaultReadinessPeriod           = time.Second * 5
 	DefaultMaxPointAge               = time.Hour * 25
 	DefaultShutdownDelay             = time.Minute
-	DefaultStartupTimeout            = time.Minute * 5
+	DefaultStartupTimeout            = time.Minute * 10
 	DefaultNoisyLogPeriod            = time.Second * 5
 	DefaultPrometheusTimeout         = time.Second * 60
 
@@ -59,6 +59,15 @@ const (
 	DefaultMaxTimeseriesPerRequest = 500
 	// Max number of shards, i.e. amount of concurrency
 	DefaultMaxShards = 200
+
+	// TODO: This was 1 minute; it's not clear how often it should
+	// happen bit it's a suspiciously short timeout given that it
+	// can race with startup.  Should we wait until the WAL reader
+	// reaches a current position before we begin garbage
+	// collection?
+	DefaultSeriesCacheGarbageCollectionPeriod = time.Minute * 15
+
+	DefaultSeriesCacheRefreshPeriod = time.Minute * 10
 
 	// TODO: The setting below is not configurable, it should be.
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,7 @@ const (
 	// collection?
 	DefaultSeriesCacheGarbageCollectionPeriod = time.Minute * 15
 
-	DefaultSeriesCacheRefreshPeriod = time.Minute * 10
+	DefaultSeriesCacheRefreshPeriod = time.Minute * 3
 
 	// TODO: The setting below is not configurable, it should be.
 

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -118,14 +118,12 @@ type seriesCacheEntry struct {
 	exported bool
 }
 
-const refreshInterval = 3 * time.Minute
-
 func (e *seriesCacheEntry) populated() bool {
 	return e.desc != nil
 }
 
 func (e *seriesCacheEntry) shouldRefresh() bool {
-	return !e.populated() && time.Since(e.lastRefresh) > refreshInterval
+	return !e.populated() && time.Since(e.lastRefresh) > config.DefaultSeriesCacheRefreshPeriod
 }
 
 func newSeriesCache(
@@ -154,7 +152,7 @@ func newSeriesCache(
 }
 
 func (c *seriesCache) run(ctx context.Context) {
-	tick := time.NewTicker(time.Minute)
+	tick := time.NewTicker(config.DefaultSeriesCacheGarbageCollectionPeriod)
 	defer tick.Stop()
 
 	for {

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -223,7 +223,7 @@ func TestSeriesCache_Refresh(t *testing.T) {
 
 	// Hack the timestamp of the last update to be sufficiently in the past that a refresh
 	// will be triggered.
-	c.entries[refID].lastRefresh = time.Now().Add(-2 * refreshInterval)
+	c.entries[refID].lastRefresh = time.Now().Add(-2 * config.DefaultSeriesCacheRefreshPeriod)
 
 	// Now another get should trigger a refresh, which now finds data.
 	entry, ok, err = c.get(ctx, refID)


### PR DESCRIPTION
This raises the startup timeout to give the sidecar more time to reach a healthy state when restarting with a busy Prometheus. This also raises the garbage collection period for the series cache, which looked dangerous.