### PR TITLE
Remove the service.instance.id label from the primary output

### DIFF
--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -271,7 +271,7 @@ func TestE2E(t *testing.T) {
 		// At this moment, the labels in static_configs are NOT
 		// passed to the Resource.
 		assert.Equal(t, rvals[string(semconv.ServiceNameKey)], "Service")
-		assert.NotEqual(t, rvals[string(semconv.ServiceInstanceIDKey)], "")
+		assert.Equal(t, rvals[string(semconv.ServiceInstanceIDKey)], "")
 
 		output[name] = append(output[name], val)
 	}


### PR DESCRIPTION
This information is creating duplicate series where there should not be. This can alter the user's data in certain situations, especially if the sidecar is restarting. A future release will include this as an external label using the __external_ prefix, which Lightstep supports.