### PR TITLE
add support for `instance` relabeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Added support for handling relabeling rules for `instance` label.
+- Added support for handling relabeling rules for `instance` label. (#175)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added support for handling relabeling rules for `instance` label.
+
 ### Changed
 
 ### Removed

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -221,19 +221,6 @@ func Main() bool {
 		return false
 	}
 
-	prometheusReader := retrieval.NewPrometheusReader(
-		log.With(logger, "component", "prom_wal"),
-		cfg.Prometheus.WAL,
-		tailer,
-		filters,
-		metricRenames,
-		metadataCache,
-		queueManager,
-		cfg.OpenTelemetry.MetricsPrefix,
-		cfg.Prometheus.MaxPointAge.Duration,
-		createPrimaryDestinationResourceLabels(svcInstanceId, cfg.Destination.Attributes),
-	)
-
 	// Start the admin server.
 	go func() {
 		defer cancelMain()
@@ -263,6 +250,20 @@ func Main() bool {
 
 	level.Debug(logger).Log("msg", "entering run state")
 	healthChecker.SetRunning()
+
+	prometheusReader := retrieval.NewPrometheusReader(
+		log.With(logger, "component", "prom_wal"),
+		cfg.Prometheus.WAL,
+		tailer,
+		filters,
+		metricRenames,
+		metadataCache,
+		queueManager,
+		cfg.OpenTelemetry.MetricsPrefix,
+		cfg.Prometheus.MaxPointAge.Duration,
+		createPrimaryDestinationResourceLabels(svcInstanceId, cfg.Destination.Attributes),
+		promMon.GetScrapeConfig(),
+	)
 
 	// Run two inter-depdendent components:
 	// (1) Prometheus reader

--- a/prometheus/monitor.go
+++ b/prometheus/monitor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prom2json"
+	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -24,7 +25,8 @@ const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client
 
 type (
 	Monitor struct {
-		cfg config.PromReady
+		cfg          config.PromReady
+		scrapeConfig []*promconfig.ScrapeConfig
 	}
 
 	Family struct {

--- a/prometheus/ready.go
+++ b/prometheus/ready.go
@@ -156,6 +156,10 @@ func (m *Monitor) GetConfig(ctx context.Context) (promconfig.Config, error) {
 
 }
 
+func (m *Monitor) GetScrapeConfig() []*promconfig.ScrapeConfig {
+	return m.scrapeConfig
+}
+
 func (m *Monitor) WaitForReady(inCtx context.Context, inCtxCancel context.CancelFunc) error {
 	u := *m.cfg.PromURL
 	u.Path = path.Join(u.Path, "/-/ready")
@@ -206,6 +210,7 @@ func (m *Monitor) WaitForReady(inCtx context.Context, inCtxCancel context.Cancel
 					inCtxCancel()
 					return false
 				}
+				m.scrapeConfig = promCfg.ScrapeConfigs
 
 				// Great! We also need it to have completed
 				// a full round of scrapes.

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -113,19 +113,6 @@ func (r *PrometheusReader) CurrentSegment() int {
 	return r.tailer.CurrentSegment()
 }
 
-// case LabelDrop:
-// 	for _, l := range lset {
-// 		if cfg.Regex.MatchString(l.Name) {
-// 			lb.Del(l.Name)
-// 		}
-// 	}
-// case LabelKeep:
-// 	for _, l := range lset {
-// 		if !cfg.Regex.MatchString(l.Name) {
-// 			lb.Del(l.Name)
-// 		}
-// 	}
-
 // getjobInstanceMap returns a string map for any job for which the instance
 // label has been relabeled
 func (r *PrometheusReader) getJobInstanceMap() map[string]string {

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -95,7 +95,7 @@ func TestReader_Progress(t *testing.T) {
 		"job1/inst1/metric1": &config.MetadataEntry{Metric: "metric1", MetricType: textparse.MetricTypeGauge, Help: "help"},
 	}
 
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, extraLabels)
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, extraLabels, nil)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -160,7 +160,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, extraLabels)
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, extraLabels, nil)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -418,8 +418,8 @@ func TestSeriesCache_Relabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entry, ok, err := c.get(ctx, 1)
-	if !ok || err != nil {
+	entry, err := c.get(ctx, 1)
+	if err != nil {
 		t.Fatalf("metric not found: %s", err)
 	}
 	if !labels.Equal(entry.lset, labels.FromStrings("__name__", "metric1", "job", "job1", "other_instance_label", "inst1")) {
@@ -432,8 +432,8 @@ func TestSeriesCache_Relabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entry, ok, err = c.get(ctx, 2)
-	if !ok || err != nil {
+	entry, err = c.get(ctx, 2)
+	if err != nil {
 		t.Fatalf("metric not found: %s", err)
 	}
 	if want := getMetricName("", "metric3"); entry.desc.Name != want {

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -833,7 +833,7 @@ func TestSampleBuilder(t *testing.T) {
 				var err error
 				var result []*metric_pb.ResourceMetrics
 
-				series := newSeriesCache(nil, "", nil, nil, c.metadata, c.metricsPrefix, c.resourceLabels)
+				series := newSeriesCache(nil, "", nil, nil, c.metadata, c.metricsPrefix, c.resourceLabels, nil)
 				for ref, s := range c.series {
 					series.set(ctx, ref, s, 0)
 				}


### PR DESCRIPTION
This change addresses an issue where users can relabel the `instance` label using prometheus relabelling rules, causing the sidecar to skip sending metrics it shouldn't because it fails to retrieve the metadata on the affected metrics.

The sidecar will now look at the Prometheus `ScrapeConfig` via the API and create a map of job name -> remapped instance label