### PR TITLE
Transition to the new current segment if we dragged behind.

### DIFF
--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -378,7 +378,7 @@ func TestErrSkipSegment(t *testing.T) {
 	require.Nil(t, err, "unexpected error")
 	require.Equal(t, 0, r.attempts)
 
-	r = fakePrometheusReader{err: tail.ErrRestartReader}
+	r = fakePrometheusReader{err: errors.New("another error")}
 	err = runReader(context.Background(), &r, "", 0, maxAttempts)
 	require.Equal(t, tail.ErrRestartReader, err)
 	require.Equal(t, 0, r.attempts)

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -28,6 +28,7 @@ import (
 	traces "github.com/lightstep/opentelemetry-prometheus-sidecar/internal/opentelemetry-proto-gen/trace/v1"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/internal/promtest"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/tail"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -378,9 +379,10 @@ func TestErrSkipSegment(t *testing.T) {
 	require.Nil(t, err, "unexpected error")
 	require.Equal(t, 0, r.attempts)
 
-	r = fakePrometheusReader{err: errors.New("another error")}
+	anotherErr := errors.New("unexpected error")
+	r = fakePrometheusReader{err: anotherErr}
 	err = runReader(context.Background(), &r, "", 0, maxAttempts)
-	require.Equal(t, tail.ErrRestartReader, err)
+	require.Equal(t, anotherErr, err)
 	require.Equal(t, 0, r.attempts)
 
 	// looping should only happen for ErrSkipSegment

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -218,6 +218,9 @@ func (t *Tailer) getCurrentSegment() int {
 	return t.nextSegment - 1
 }
 
+// Offset is reset as in incNextSegment()
+// as we *just* started pointing to the *current*
+// segment.
 func (t *Tailer) setCurrentSegment(segment int) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
@@ -448,7 +451,7 @@ func (t *Tailer) Read(b []byte) (int, error) {
 		if err == record.ErrNotFound && promSeg > nextSegment {
 			t.setCurrentSegment(promSeg)
 			level.Warn(t.logger).Log(
-				"msg", "past WAL segment not found, transition to the new current segment",
+				"msg", "past WAL segment not found, sidecar may have dragged behind. Consider increasing max-shards and max-timeseries-per-request values",
 				"segment", nextSegment,
 				"current", promSeg,
 				"checkpoint", getCheckpointFilenames(t.dir),

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,6 +50,9 @@ const (
 	// the Prom code makes this a variable, the application does
 	// not (apparently?) expose it as a variable, so we hard-code.
 	promSegmentSize = wal.DefaultSegmentSize
+
+	// The prefix of the checkpoint files.
+	checkpointPrefix = "checkpoint."
 )
 
 var (
@@ -77,7 +81,6 @@ var (
 		),
 	)
 
-	ErrRestartReader = errors.New("sidecar fell behind, restarting reader")
 	ErrSkipSegment   = errors.New("skip truncated WAL segment")
 )
 
@@ -213,6 +216,13 @@ func (t *Tailer) getCurrentSegment() int {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	return t.nextSegment - 1
+}
+
+func (t *Tailer) setCurrentSegment(segment int) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	t.nextSegment = segment + 1
+	t.offset = 0
 }
 
 // Offset returns the approximate current position of the tailer in the WAL with
@@ -436,12 +446,19 @@ func (t *Tailer) Read(b []byte) (int, error) {
 		next, err := openSegment(t.dir, nextSegment)
 
 		if err == record.ErrNotFound && promSeg > nextSegment {
+			t.setCurrentSegment(promSeg)
 			level.Warn(t.logger).Log(
-				"msg", "past WAL segment not found, will restart the reader",
+				"msg", "past WAL segment not found, transition to the new current segment",
 				"segment", nextSegment,
 				"current", promSeg,
+				"checkpoint", getCheckpointFilenames(t.dir),
 			)
-			return 0, ErrRestartReader
+			next, err = openSegment(t.dir, promSeg)
+			if err != nil {
+				return 0, errors.Wrap(err, "open next segment")
+			}
+			t.cur = next
+			continue
 		}
 
 		if err != nil {
@@ -455,6 +472,32 @@ func (t *Tailer) Read(b []byte) (int, error) {
 		)
 		t.cur = next
 	}
+}
+
+// getCheckpointFilenames looks for checkpoint filenames, in order to
+// debug cases where the sidecar dragged behind the current Prometheus
+// segment. A single checkpoint file should exist at all times, but
+// we check for more in case of exotic scenarios.
+func getCheckpointFilenames(dir string) string {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	var filenames string
+	found := false
+	for _, entry := range files {
+		name := entry.Name()
+		if !strings.HasPrefix(name, checkpointPrefix) {
+			continue
+		}
+
+		if found {
+			filenames += ","
+		}
+		found = true
+		filenames += name[len(checkpointPrefix):]
+	}
+	return filenames
 }
 
 // openSegment finds a WAL segment with a name that parses to n. This


### PR DESCRIPTION
Before we were restarting the sidecar for this case - now we
simply adjust the current segment to the one *actually* used
by Prometheus. Datapoints will still be lost, but we adapt
slightly better (and a complete fix is still due).