### PR TITLE
minor change to improve output

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -285,6 +285,8 @@ func (a *alive) check(metrics map[string][]exportRecord) error {
 	produced := sumWhere(config.ProducedMetric, "")
 
 	if produced.defined() && produced.matchDelta() == 0 {
+		// if the sidecar has not been able to produced samples, it's
+		// possible that all series are being filtered
 		if produced.matchValue() == 0 {
 			return errors.Errorf("no samples produced, check filter configuration")
 		}

--- a/health/health.go
+++ b/health/health.go
@@ -228,7 +228,6 @@ func (a *alive) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			resp = a.lastResponse
 		}
-
 		return resp
 	})
 }
@@ -286,6 +285,9 @@ func (a *alive) check(metrics map[string][]exportRecord) error {
 	produced := sumWhere(config.ProducedMetric, "")
 
 	if produced.defined() && produced.matchDelta() == 0 {
+		if produced.matchValue() == 0 {
+			return errors.Errorf("no samples produced, check filter configuration")
+		}
 		return errors.Errorf(
 			"%s stopped moving at %v",
 			config.ProducedMetric,

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -258,7 +258,7 @@ func (s *Supervisor) healthcheckErr(ctx context.Context) (err error) {
 		}
 
 		if resp.StatusCode/100 != 2 {
-			return errors.Errorf("healthcheck: %s", resp.Status)
+			return errors.Errorf("healthcheck: %s", hr.Status)
 		}
 
 		return nil


### PR DESCRIPTION
If a user configures the sidecar filter to filter out all samples, the sidecar exits
with 503 message. This change updates the message to display the error status from the healthcheck
response and updates the healthcheck to output a message with some action for the
user.

Fixes #176 