### PR TITLE
Add error detail for export failures

### DIFF
--- a/otlp/client.go
+++ b/otlp/client.go
@@ -289,6 +289,7 @@ func (c *Client) Store(req *metricsService.ExportMetricsServiceRequest) error {
 						"err", truncateErrorString(err),
 						"size", proto.Size(reqCopy),
 						"trailers", fmt.Sprint(md),
+						"recoverable", isRecoverable(err),
 					)
 				})
 				errors <- err

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -283,12 +283,14 @@ func (c *Client) Store(req *metricsService.ExportMetricsServiceRequest) error {
 			defer exportDuration.Start(ctx).Stop(&err)
 
 			if _, err = service.Export(c.grpcMetadata(ctx), reqCopy, grpc.Trailer(&md)); err != nil {
-				level.Debug(c.logger).Log(
-					"msg", "export failure",
-					"err", truncateErrorString(err),
-					"size", proto.Size(reqCopy),
-					"trailers", fmt.Sprint(md),
-				)
+				doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
+					level.Error(c.logger).Log(
+						"msg", "export failure",
+						"err", truncateErrorString(err),
+						"size", proto.Size(reqCopy),
+						"trailers", fmt.Sprint(md),
+					)
+				})
 				errors <- err
 				return
 			}


### PR DESCRIPTION
An export error would be printed as a debug-level and then again as a noisy-log inside the recoverable-error code path in queue_manager.go. Since that log could be elided, printing it as a noisy log here will help understand export errors as distinct from metadata-not-found and other errors.