### PR TITLE
Less noise from logs in general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Series cache remembers points that were filtered in order to correctly count points that are dropped. (#174)
 - Metric `sidecar.metadata.fetch.duration` has new `mode` label for single and batch requests. (#174)
+- Noisy logs are reduced to emitting once per minute. (#181)
 
 ### Removed
 

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ const (
 	DefaultMaxPointAge               = time.Hour * 25
 	DefaultShutdownDelay             = time.Minute
 	DefaultStartupTimeout            = time.Minute * 10
-	DefaultNoisyLogPeriod            = time.Second * 5
+	DefaultNoisyLogPeriod            = time.Second * 60
 	DefaultPrometheusTimeout         = time.Second * 60
 
 	DefaultSupervisorBufferSize  = 16384


### PR DESCRIPTION
Reduces noise to let us see more distinct statements in our supervisor spans.