### PR TITLE
remove healthcheck metrics from telemetry traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Removed
+- Removed healthcheck metrics from telemetry traces
+
 ## [0.21.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.21.0) - 2021-04-06
 ### Added
 
@@ -23,8 +26,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Series cache remembers points that were filtered in order to correctly count points that are dropped. (#174)
 - Metric `sidecar.metadata.fetch.duration` has new `mode` label for single and batch requests. (#174)
 - Noisy logs are reduced to emitting once per minute. (#181)
-
-### Removed
 
 ## [0.20.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.20.1) - 2021-03-23
 

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -249,14 +249,6 @@ func (s *Supervisor) healthcheckErr(ctx context.Context) (err error) {
 			span.SetAttributes(attribute.String("sidecar.stackdump", hr.Stackdump))
 		}
 
-		for k, es := range hr.Metrics {
-			for _, e := range es {
-				span.SetAttributes(
-					attribute.Float64(fmt.Sprintf("%s{%s}", k, e.Labels), e.Value),
-				)
-			}
-		}
-
 		if resp.StatusCode/100 != 2 {
 			return errors.Errorf("healthcheck: %s", hr.Status)
 		}


### PR DESCRIPTION
The healthcheck metrics were not super useful and causing some other attributes to be discarded on ingest due to limits.