### PR TITLE
account for histograms sidecar counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - OTLP data points re-use Resource and InstrumentationLibrary (thus are smaller). (#182)
-- Counters `sidecar.samples.produced` `sidecar.points.skipped` `sidecar.points.dropped`
-  and `sidecar.samples.processed` now account for histograms. (#187)
+
+### Removed
+
+- Removed counters `sidecar.samples.produced` & `sidecar.samples.processed`. (#187)
 
 ## [0.21.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.21.1) - 2021-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- New metric `sidecar.points.processed` counts total points processed from the WAL. (#187)
+- New metric `sidecar.points.produced` counts total points produced from the WAL. (#187)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- New metric `sidecar.points.processed` counts total points processed from the WAL. (#187)
+
 ### Changed
 
 - OTLP data points re-use Resource and InstrumentationLibrary (thus are smaller). (#182)
+- Counters `sidecar.samples.produced` `sidecar.points.skipped` `sidecar.points.dropped`
+  and `sidecar.samples.processed` now account for histograms. (#187)
 
 ## [0.21.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.21.1) - 2021-04-06
 

--- a/README.md
+++ b/README.md
@@ -461,8 +461,6 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.queue.running | gauge | number of running shards, those which have not exited | |
 | sidecar.queue.shards | gauge | number of current shards, as set by the queue manager | |
 | sidecar.queue.size | gauge | number of samples (i.e., points) standing in a queue waiting to export | |
-| sidecar.samples.processed | histogram | number of metric samples read in a prometheus WAL batch | |
-| sidecar.samples.produced | counter | number of metric samples produced | |
 | sidecar.series.defined | counter | number of series defined in the WAL | |
 | sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: various |
 | sidecar.points.produced | counter | number of points read from the prometheus WAL | |

--- a/README.md
+++ b/README.md
@@ -461,10 +461,11 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.queue.running | gauge | number of running shards, those which have not exited | |
 | sidecar.queue.shards | gauge | number of current shards, as set by the queue manager | |
 | sidecar.queue.size | gauge | number of samples (i.e., points) standing in a queue waiting to export | |
-| sidecar.samples.processed | histogram | number of samples (i.e., points) read in a prometheus WAL batch | |
-| sidecar.samples.produced | counter | number of samples (i.e., points) read from the prometheus WAL | |
+| sidecar.samples.processed | histogram | number of metric samples read in a prometheus WAL batch | |
+| sidecar.samples.produced | counter | number of metric samples produced | |
 | sidecar.series.defined | counter | number of series defined in the WAL | |
 | sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: various |
+| sidecar.points.produced | counter | number of points read from the prometheus WAL | |
 | sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: various |
 | sidecar.points.skipped | counter | number of points skipped by filters or cumulative resets | |
 | sidecar.metadata.lookups | counter | number of calls to lookup metadata | `error`: true, false |

--- a/config/config.go
+++ b/config/config.go
@@ -97,15 +97,16 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 
 	// Some metric names are shared across packages, for healthchecking.
 
-	SidecarPrefix        = "sidecar."
-	ProcessedMetric      = "sidecar.samples.processed"
-	ProducedMetric       = "sidecar.samples.produced"
-	SeriesDefinedMetric  = "sidecar.series.defined"
-	OutcomeMetric        = "sidecar.queue.outcome"
-	DroppedSeriesMetric  = "sidecar.series.dropped"
-	DroppedPointsMetric  = "sidecar.points.dropped"
-	SkippedPointsMetric  = "sidecar.points.skipped"
-	InvalidMetricsMetric = "sidecar.metrics.invalid"
+	SidecarPrefix         = "sidecar."
+	ProcessedMetric       = "sidecar.samples.processed"
+	ProducedMetric        = "sidecar.samples.produced"
+	SeriesDefinedMetric   = "sidecar.series.defined"
+	OutcomeMetric         = "sidecar.queue.outcome"
+	DroppedSeriesMetric   = "sidecar.series.dropped"
+	ProcessedPointsMetric = "sidecar.points.processed"
+	DroppedPointsMetric   = "sidecar.points.dropped"
+	SkippedPointsMetric   = "sidecar.points.skipped"
+	InvalidMetricsMetric  = "sidecar.metrics.invalid"
 
 	OutcomeKey          = attribute.Key("outcome")
 	OutcomeSuccessValue = "success"
@@ -246,7 +247,7 @@ func DefaultMainConfig() MainConfig {
 			Endpoint:                DefaultPrometheusEndpoint,
 			MaxPointAge:             DurationConfig{DefaultMaxPointAge},
 			MaxTimeseriesPerRequest: DefaultMaxTimeseriesPerRequest,
-			MinShards:		 DefaultMinShards,
+			MinShards:               DefaultMinShards,
 			MaxShards:               DefaultMaxShards,
 		},
 		Admin: AdminConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -97,16 +97,14 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 
 	// Some metric names are shared across packages, for healthchecking.
 
-	SidecarPrefix         = "sidecar."
-	ProcessedMetric       = "sidecar.samples.processed"
-	ProducedMetric        = "sidecar.samples.produced"
-	SeriesDefinedMetric   = "sidecar.series.defined"
-	OutcomeMetric         = "sidecar.queue.outcome"
-	DroppedSeriesMetric   = "sidecar.series.dropped"
-	ProcessedPointsMetric = "sidecar.points.processed"
-	DroppedPointsMetric   = "sidecar.points.dropped"
-	SkippedPointsMetric   = "sidecar.points.skipped"
-	InvalidMetricsMetric  = "sidecar.metrics.invalid"
+	SidecarPrefix        = "sidecar."
+	SeriesDefinedMetric  = "sidecar.series.defined"
+	OutcomeMetric        = "sidecar.queue.outcome"
+	DroppedSeriesMetric  = "sidecar.series.dropped"
+	ProducedPointsMetric = "sidecar.points.produced"
+	DroppedPointsMetric  = "sidecar.points.dropped"
+	SkippedPointsMetric  = "sidecar.points.skipped"
+	InvalidMetricsMetric = "sidecar.metrics.invalid"
 
 	OutcomeKey          = attribute.Key("outcome")
 	OutcomeSuccessValue = "success"

--- a/health/health.go
+++ b/health/health.go
@@ -282,7 +282,7 @@ func (a *alive) check(metrics map[string][]exportRecord) error {
 		return t
 	}
 
-	produced := sumWhere(config.ProducedMetric, "")
+	produced := sumWhere(config.ProducedPointsMetric, "")
 
 	if produced.defined() && produced.matchDelta() == 0 {
 		// if the sidecar has not been able to produced samples, it's
@@ -292,7 +292,7 @@ func (a *alive) check(metrics map[string][]exportRecord) error {
 		}
 		return errors.Errorf(
 			"%s stopped moving at %v",
-			config.ProducedMetric,
+			config.ProducedPointsMetric,
 			produced.matchValue(),
 		)
 	}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -43,7 +43,7 @@ type tester struct {
 func testController(t *testing.T) *tester {
 	cont := telemetry.InternalOnly().Controller
 	provider := cont.MeterProvider()
-	produced := metric.Must(provider.Meter("test")).NewInt64Counter(config.ProducedMetric)
+	produced := metric.Must(provider.Meter("test")).NewInt64Counter(config.ProducedPointsMetric)
 	outcome := metric.Must(provider.Meter("test")).NewInt64Counter(config.OutcomeMetric)
 
 	checker := NewChecker(cont, 0 /* uncached */, telemetry.DefaultLogger(), config.DefaultHealthCheckThresholdRatio)
@@ -106,7 +106,7 @@ func TestProducedProgress(t *testing.T) {
 		require.Equal(t, http.StatusServiceUnavailable, code)
 		require.Contains(t, result.Status,
 			fmt.Sprintf("unhealthy: %s stopped moving at %d",
-				config.ProducedMetric,
+				config.ProducedPointsMetric,
 				k,
 			),
 		)

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	datapointsProcessed = sidecar.OTelMeterMust.NewInt64ValueRecorder(
-		config.ProcessedMetric,
+		config.ProcessedPointsMetric,
 		metric.WithDescription("Number of WAL data points processed in a batch"),
 	)
 

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -44,7 +44,7 @@ var (
 
 	samplesProcessed = sidecar.OTelMeterMust.NewInt64ValueRecorder(
 		config.ProcessedMetric,
-		metric.WithDescription("Number of WAL samples processed in a batch"),
+		metric.WithDescription("Number of Metric samples processed in a batch"),
 	)
 
 	samplesProduced = sidecar.OTelMeterMust.NewInt64Counter(

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -237,7 +237,7 @@ Outer:
 				continue
 			}
 			processed, produced := len(samples), 0
-			droppedPoints, skippedPoints := 0, 0
+			points, droppedPoints, skippedPoints := 0, 0, 0
 
 			for len(samples) > 0 {
 				select {
@@ -248,27 +248,30 @@ Outer:
 
 				outputSample, hash, newSamples, err := builder.next(ctx, samples)
 
+				points = len(samples) - len(newSamples)
+
 				if len(samples) == len(newSamples) {
 					// Note: There are a few code paths in `builder.next()`
 					// where it's easier to fall through to this than to be
 					// sure the samples list becomes shorter by at least 1.
 					samples = samples[1:]
+					points = 1
 				} else {
 					samples = newSamples
 				}
 				if err != nil {
-					droppedPoints++
+					droppedPoints += points
 					doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
 						level.Warn(r.logger).Log("msg", "failed to build sample", "err", err)
 					})
 					continue
 				}
 				if outputSample == nil {
-					skippedPoints++
+					skippedPoints += points
 					continue
 				}
 				r.appender.Append(ctx, hash, outputSample)
-				produced++
+				produced += points
 			}
 
 			if droppedPoints != 0 {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -380,7 +380,7 @@ func (s *Supervisor) noteHealthy(hr health.Response) string {
 	} else {
 		summary = append(summary, "msg", "sidecar is running")
 
-		summary = append(summary, hr.MetricLogSummary(config.ProcessedMetric)...)
+		summary = append(summary, hr.MetricLogSummary(config.ProducedPointsMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.OutcomeMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedSeriesMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedPointsMetric)...)


### PR DESCRIPTION
There was a discrepancy between the number of samples being reported back as processed and the number either produced, skipped or dropped. This was caused by a bug in accounting for histograms, this PR fixes that.

After this PR, `sidecar.samples.processed` now equal the number of metric samples processed. The total number of data points read from the WAL exist in `sidecar.points.processed`. This makes using of other metrics like `queue.outcome{success}` easier, as it counts the number of metrics exported, rather than the number of total datapoints.