### PR TITLE
Reset tailer on skip segment errors

### DIFF
--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -66,8 +66,8 @@ func StartComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTai
 				break
 			}
 			attempts += 1
-			tailer.SetCurrentSegment(currentSegment + 1)
-			startOffset = (currentSegment + 1) * wal.DefaultSegmentSize
+			tailer.SetCurrentSegment(currentSegment)
+			startOffset = currentSegment * wal.DefaultSegmentSize
 			continue
 		}
 		break

--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -1,0 +1,119 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/metadata"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/otlp"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/prometheus"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/retrieval"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/tail"
+	"github.com/oklog/run"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb/wal"
+)
+
+type SidecarConfig struct {
+	ClientFactory otlp.StorageClientFactory
+	Monitor       *prometheus.Monitor
+	Logger        log.Logger
+	InstanceId    string
+	Filters       [][]*labels.Matcher
+	MetricRenames map[string]string
+	MetadataCache *metadata.Cache
+
+	config.MainConfig
+}
+
+// createPrimaryDestinationResourceLabels returns the OTLP resources
+// to use for the primary destination.
+func createPrimaryDestinationResourceLabels(svcInstanceId string, extraLabels map[string]string) labels.Labels {
+	// Note: there is minor benefit in including an external label
+	// to indicate the process ID here.  See
+	// https://github.com/lightstep/opentelemetry-prometheus-sidecar/issues/44
+	// Until resources are serialized once per request, leave this
+	// commented out (and a test in e2e_test.go):
+	// extraLabels[externalLabelPrefix+string(semconv.ServiceInstanceIDKey)]
+	// = svcInstanceId
+	return labels.FromMap(extraLabels)
+}
+
+func StartComponents(ctx context.Context, scfg SidecarConfig, tailer *tail.Tailer, startOffset int) (int, error) {
+	// Run two inter-dependent components:
+	// (1) Prometheus reader
+	// (2) Queue manager
+	// TODO: Replace this with x/sync/errgroup
+	currentSegment := 0
+	queueManager, err := otlp.NewQueueManager(
+		log.With(scfg.Logger, "component", "queue_manager"),
+		scfg.QueueConfig(),
+		scfg.Destination.Timeout.Duration,
+		scfg.ClientFactory,
+		tailer,
+		retrieval.LabelsToResource(createPrimaryDestinationResourceLabels(scfg.InstanceId, scfg.Destination.Attributes)),
+	)
+	if err != nil {
+		level.Error(scfg.Logger).Log("msg", "creating queue manager failed", "err", err)
+		return currentSegment, err
+	}
+
+	prometheusReader := retrieval.NewPrometheusReader(
+		log.With(scfg.Logger, "component", "prom_wal"),
+		scfg.Prometheus.WAL,
+		tailer,
+		scfg.Filters,
+		scfg.MetricRenames,
+		scfg.MetadataCache,
+		queueManager,
+		scfg.OpenTelemetry.MetricsPrefix,
+		scfg.Prometheus.MaxPointAge.Duration,
+		scfg.Monitor.GetScrapeConfig(),
+	)
+
+	var g run.Group
+	{
+		g.Add(
+			func() error {
+				level.Info(scfg.Logger).Log("msg", "starting Prometheus reader", "segment", startOffset/wal.DefaultSegmentSize)
+				return prometheusReader.Run(ctx, startOffset)
+			},
+			func(err error) {
+				// Prometheus reader needs to be stopped before closing the TSDB
+				// so that it doesn't try to write samples to a closed storage.
+				// See the use of `stopCh` below to explain how this works.
+				level.Info(scfg.Logger).Log("msg", "stopping Prometheus reader")
+			},
+		)
+	}
+	{
+		stopCh := make(chan struct{})
+		g.Add(
+			func() error {
+				if err := queueManager.Start(); err != nil {
+					return err
+				}
+				level.Info(scfg.Logger).Log("msg", "starting OpenTelemetry writer")
+				<-stopCh
+				return nil
+			},
+			func(err error) {
+				if err := queueManager.Stop(); err != nil {
+					level.Error(scfg.Logger).Log(
+						"msg", "stopping OpenTelemetry writer",
+						"err", err,
+					)
+				}
+				close(stopCh)
+			},
+		)
+	}
+
+	if err := g.Run(); err != nil {
+		level.Error(scfg.Logger).Log("msg", "run loop error", "err", err)
+		return prometheusReader.CurrentSegment(), err
+	}
+	return prometheusReader.CurrentSegment(), nil
+}

--- a/cmd/internal/start_components_test.go
+++ b/cmd/internal/start_components_test.go
@@ -1,0 +1,98 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/prometheus"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/tail"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTailer struct {
+	readError error
+	sizeError error
+}
+
+func (t *fakeTailer) Size() (int, error) {
+	return 0, t.sizeError
+}
+
+func (t *fakeTailer) Next() {
+}
+
+func (t *fakeTailer) Offset() int {
+	return 0
+}
+
+func (t *fakeTailer) Close() error {
+	return nil
+}
+
+func (t *fakeTailer) CurrentSegment() int {
+	return 0
+}
+
+func (t *fakeTailer) Read(b []byte) (int, error) {
+	return 0, t.readError
+}
+
+func (t *fakeTailer) SetCurrentSegment(int) {
+}
+
+var _ tail.WalTailer = &fakeTailer{}
+
+func TestStartComponents(t *testing.T) {
+	// test that we only loop for err skip segment
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	scfg := SidecarConfig{}
+	scfg.Monitor = &prometheus.Monitor{}
+	scfg.Logger = logger
+	ctx := context.Background()
+	tailer := fakeTailer{
+		sizeError: errors.New("failed to get size"),
+		readError: errors.New("failed to read"),
+	}
+	err := StartComponents(ctx, scfg, &tailer, 0)
+	require.Error(t, err)
+
+	tailer = fakeTailer{
+		sizeError: tail.ErrSkipSegment,
+		readError: errors.New("failed to read"),
+	}
+	err = StartComponents(ctx, scfg, &tailer, 0)
+	require.Error(t, err)
+
+	tailer = fakeTailer{
+		readError: errors.New("failed to read"),
+	}
+	err = StartComponents(ctx, scfg, &tailer, 0)
+	require.Error(t, err)
+
+	tailer = fakeTailer{
+		readError: tail.ErrSkipSegment,
+		// readError: errors.New("failed to read"),
+	}
+	err = StartComponents(ctx, scfg, &tailer, 0)
+	require.Error(t, err)
+
+	// r := fakePrometheusReader{}
+	// err := runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
+	// require.Nil(t, err, "unexpected error")
+	// require.Equal(t, 0, r.attempts)
+
+	// anotherErr := errors.New("unexpected error")
+	// r = fakePrometheusReader{err: anotherErr}
+	// err = runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
+	// require.Equal(t, anotherErr, err)
+	// require.Equal(t, 0, r.attempts)
+
+	// // looping should only happen for ErrSkipSegment
+	// r = fakePrometheusReader{err: tail.ErrSkipSegment}
+	// err = runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
+	// require.Equal(t, tail.ErrSkipSegment, err)
+	// require.Equal(t, 5, r.attempts)
+}

--- a/cmd/internal/start_components_test.go
+++ b/cmd/internal/start_components_test.go
@@ -74,25 +74,8 @@ func TestStartComponents(t *testing.T) {
 
 	tailer = fakeTailer{
 		readError: tail.ErrSkipSegment,
-		// readError: errors.New("failed to read"),
 	}
 	err = StartComponents(ctx, scfg, &tailer, 0)
 	require.Error(t, err)
 
-	// r := fakePrometheusReader{}
-	// err := runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
-	// require.Nil(t, err, "unexpected error")
-	// require.Equal(t, 0, r.attempts)
-
-	// anotherErr := errors.New("unexpected error")
-	// r = fakePrometheusReader{err: anotherErr}
-	// err = runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
-	// require.Equal(t, anotherErr, err)
-	// require.Equal(t, 0, r.attempts)
-
-	// // looping should only happen for ErrSkipSegment
-	// r = fakePrometheusReader{err: tail.ErrSkipSegment}
-	// err = runReader(context.Background(), &r, "", 0, maxAttempts, logger, nil)
-	// require.Equal(t, tail.ErrSkipSegment, err)
-	// require.Equal(t, 5, r.attempts)
 }

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -152,7 +152,7 @@ func Main() bool {
 		StartupDelayEffectiveStartTime: time.Now(),
 	})
 
-	failingSet := common.NewFailingSet(log.With(logger, "component", "failing"))
+	failingSet := common.NewFailingSet(log.With(scfg.Logger, "component", "failing"))
 
 	metadataURL, err := promURL.Parse(config.PrometheusMetadataEndpointPath)
 	if err != nil {

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -61,7 +61,7 @@ type MetadataGetter interface {
 func NewPrometheusReader(
 	logger log.Logger,
 	walDirectory string,
-	tailer *tail.Tailer,
+	tailer tail.WalTailer,
 	filters [][]*labels.Matcher,
 	metricRenames map[string]string,
 	metadataGetter MetadataGetter,
@@ -91,7 +91,7 @@ func NewPrometheusReader(
 type PrometheusReader struct {
 	logger               log.Logger
 	walDirectory         string
-	tailer               *tail.Tailer
+	tailer               tail.WalTailer
 	filters              [][]*labels.Matcher
 	metricRenames        map[string]string
 	metadataGetter       MetadataGetter


### PR DESCRIPTION
The current implementation of skipping truncated wal segments is causing an issue where a truncated segment is found, and the sidecar skips it without updating the `tailer`, which can cause issues if the checkpoint has been updated. The checkpoint files are only read in the initialization of the `tailer`. This PR moves logic to init prometheus reader and queue manager to support resetting tailer on `ErrSkipSegment`