### PR TITLE
Output zero values at reset points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - OTLP data points re-use Resource and InstrumentationLibrary (thus are smaller). (#182)
+- Counter reset events output zero values at the reset timestamp, instead of skipping points. (#190)
 
 ### Removed
 
 - Removed counters `sidecar.samples.produced` & `sidecar.samples.processed`. (#187)
+- Removed counter `sidecar.cumulative.missing_resets`. (#190)
+- Removed overlap detection, this cannot happen without the MonitoredResource transform removed in #2. (#190)
 
 ## [0.21.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.21.1) - 2021-04-06
 

--- a/README.md
+++ b/README.md
@@ -465,9 +465,8 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: various |
 | sidecar.points.produced | counter | number of points read from the prometheus WAL | |
 | sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: various |
-| sidecar.points.skipped | counter | number of points skipped by filters or cumulative resets | |
+| sidecar.points.skipped | counter | number of points skipped due to filters | |
 | sidecar.metadata.lookups | counter | number of calls to lookup metadata | `error`: true, false |
-| sidecar.cumulative.missing_resets | counter | number of points skipped because cumulative reset time was not known | |
 | sidecar.series.current | gauge | number of series refs in the series cache | `status`: live, filtered, invalid |
 | sidecar.wal.size | gauge | size of the prometheus WAL | |
 | sidecar.wal.offset | gauge | current offset in the prometheus WAL | |

--- a/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/e2e_test.go
@@ -350,9 +350,9 @@ func TestE2E(t *testing.T) {
 	}
 
 	expect := map[string][]float64{
-		"some_counter":         {1, 2, 3, 4, 5},
+		"some_counter":         {0, 1, 2, 3, 4},
 		"some_gauge":           {1, 2, 3, 4, 5},
-		"some_counter_relabel": {1, 2, 3, 4, 5},
+		"some_counter_relabel": {0, 1, 2, 3, 4},
 		"some_gauge_relabel":   {1, 2, 3, 4, 5},
 	}
 

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -31,9 +31,9 @@ import (
 	promconfig "github.com/prometheus/prometheus/config"
 	"go.opentelemetry.io/otel/metric"
 	metricsService "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
-	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 
 	// gRPC Status protobuf types we may want to see.  This type
 	// is not widely used, but is the most standard way to itemize
@@ -357,12 +357,14 @@ func (t *QueueManager) calculateDesiredShards() {
 	// to shardUpdateDuration.
 	select {
 	case t.reshardChan <- numShards:
-		level.Info(t.logger).Log(
-			"msg", "send queue resharding",
-			"from", t.numShards,
-			"to", numShards,
-		)
-		t.numShards = numShards
+		if numShards != t.numShards {
+			level.Info(t.logger).Log(
+				"msg", "send queue resharding",
+				"from", t.numShards,
+				"to", numShards,
+			)
+			t.numShards = numShards
+		}
 	default:
 		level.Warn(t.logger).Log(
 			"msg", "currently resharding, skipping",

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -311,12 +311,8 @@ func (c *seriesCache) getResetAdjusted(e *seriesCacheEntry, t int64, v float64) 
 	}
 	if v < e.previousValue {
 		// If the value has dropped, there's been a reset.
-		// If the series was reset, set the reset timestamp to be one millisecond
-		// before the timestamp of the current sample.
-		// We don't know the true reset time but this ensures the range is non-zero
-		// while unlikely to conflict with any previous sample.
 		e.resetValue = 0
-		e.resetTimestamp = t - 1
+		e.resetTimestamp = t
 	}
 	e.previousValue = v
 	return e.resetTimestamp, v - e.resetValue

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -126,10 +126,6 @@ var (
 		"sidecar.metadata.lookups",
 		"Number of Metric series lookups",
 	)
-	seriesCacheMissingResetCounter = telemetry.NewCounter(
-		"sidecar.cumulative.missing_resets",
-		"Number of Metric series resets that were missing start time, causing gaps a series",
-	)
 
 	errSeriesNotFound        = fmt.Errorf("series ref not found")
 	errSeriesMissingMetadata = fmt.Errorf("series ref missing metadata")
@@ -311,8 +307,6 @@ func (c *seriesCache) getResetAdjusted(e *seriesCacheEntry, t int64, v float64) 
 		e.previousValue = v
 		// If we just initialized the reset timestamp, record a zero (i.e., reset).
 		// The next sample will be considered relative to resetValue.
-
-		seriesCacheMissingResetCounter.Add(context.Background(), 1, nil)
 		return t, 0
 	}
 	if v < e.previousValue {

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -467,7 +467,7 @@ func TestSeriesCache_ResetBehavior(t *testing.T) {
 		cumulative float64
 	}
 
-	const pad = 1
+	const pad = 0 // OTLP allows zero-width points
 
 	// Simulate two resets.
 	for i, k := range []kase{

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -457,7 +457,7 @@ func TestSeriesCache_ResetBehavior(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	_, err := c.get(ctx, refID)
+	entry, err := c.get(ctx, refID)
 	require.NoError(t, err)
 
 	type kase struct {
@@ -465,32 +465,26 @@ func TestSeriesCache_ResetBehavior(t *testing.T) {
 		value      float64
 		reset      int64
 		cumulative float64
-		ok         bool
 	}
 
 	const pad = 1
 
 	// Simulate two resets.
 	for i, k := range []kase{
-		{1, 10, 1, 0, false},
-		{2, 20, 1, 10, true},
-		{3, 30, 1, 20, true},
-		{4, 40, 1, 30, true},
+		{1, 10, 1, 0},
+		{2, 20, 1, 10},
+		{3, 30, 1, 20},
+		{4, 40, 1, 30},
 
-		{5, 5, 5 - pad, 5, true},
-		{6, 10, 5 - pad, 10, true},
-		{7, 15, 5 - pad, 15, true},
+		{5, 5, 5 - pad, 5},
+		{6, 10, 5 - pad, 10},
+		{7, 15, 5 - pad, 15},
 
-		{8, 0, 8 - pad, 0, true},
-		{9, 10, 8 - pad, 10, true},
+		{8, 0, 8 - pad, 0},
+		{9, 10, 8 - pad, 10},
 	} {
-		ts, val, ok := c.getResetAdjusted(refID, k.ts, k.value)
+		ts, val := c.getResetAdjusted(entry, k.ts, k.value)
 
-		require.Equal(t, k.ok, ok, "%d", i)
-
-		if !ok {
-			continue
-		}
 		require.Equal(t, k.reset, ts, "%d", i)
 		require.Equal(t, k.cumulative, val, "%d", i)
 	}

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -211,7 +211,16 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 9, T: 9000, V: 4},
 			},
 			result: []*metric_pb.Metric{
-				nil, // Skipped by reset timestamp handling.
+				DoubleCounterPoint( // 1: second point in series, first reported.
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric2",
+					time.Unix(2, 0),
+					time.Unix(2, 0),
+					0,
+				),
 				DoubleCounterPoint( // 1: second point in series, first reported.
 					Labels(
 						Label("instance", "instance1"),
@@ -315,7 +324,17 @@ func TestSampleBuilder(t *testing.T) {
 					time.Unix(8, 0),
 					13,
 				),
-				nil, // 9; Skipped by reset timestamp handling.
+				IntCounterPoint( // 9
+					// An integer counter.
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric4",
+					time.Unix(6, 0),
+					time.Unix(6, 0),
+					0,
+				),
 				IntCounterPoint( // 10
 					// An integer counter.
 					Labels(
@@ -336,7 +355,16 @@ func TestSampleBuilder(t *testing.T) {
 					"metric5",
 					time.Unix(8, 0),
 					22.5),
-				nil, // 12; Skipped by reset timestamp handling.
+				DoubleCounterPoint( // 12
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric6",
+					time.Unix(8, 0),
+					time.Unix(8, 0),
+					0,
+				),
 				DoubleCounterPoint( // 13
 					Labels(
 						Label("instance", "instance1"),
@@ -393,7 +421,16 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 4, T: 4000, V: 4},
 			},
 			result: []*metric_pb.Metric{
-				nil, // 0: dropped by reset handling.
+				DoubleCounterPoint(
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1_sum",
+					time.Unix(1, 0),
+					time.Unix(1, 0),
+					0,
+				),
 				DoubleCounterPoint(
 					Labels(
 						Label("instance", "instance1"),
@@ -414,7 +451,16 @@ func TestSampleBuilder(t *testing.T) {
 					time.Unix(2, 0),
 					2,
 				),
-				nil, // 3: dropped
+				IntCounterPoint(
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1_count",
+					time.Unix(3, 0),
+					time.Unix(3, 0),
+					0,
+				),
 				IntCounterPoint(
 					Labels(
 						Label("instance", "instance1"),
@@ -486,7 +532,22 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 10, T: 1000, V: 3},
 			},
 			result: []*metric_pb.Metric{
-				nil, // 0: skipped by reset handling.
+				DoubleHistogramPoint( // 0:
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(1, 0),
+					time.Unix(1, 0),
+					0,
+					0,
+					DoubleHistogramBucket(0.1, 0),
+					DoubleHistogramBucket(0.5, 0),
+					DoubleHistogramBucket(1, 0),
+					DoubleHistogramBucket(2.5, 0),
+					DoubleHistogramBucket(math.Inf(+1), 0),
+				),
 				DoubleHistogramPoint( // 1:
 					Labels(
 						Label("instance", "instance1"),
@@ -503,7 +564,18 @@ func TestSampleBuilder(t *testing.T) {
 					DoubleHistogramBucket(2.5, 2),
 					DoubleHistogramBucket(math.Inf(+1), 4),
 				),
-				nil, // 2: skipped
+				DoubleHistogramPoint( // 2: histogram w/ no buckets
+					Labels(
+						Label("a", "b"),
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(1, 0),
+					time.Unix(1, 0),
+					0,
+					0,
+				),
 				DoubleHistogramPoint( // 3: histogram w/ no buckets
 					Labels(
 						Label("a", "b"),
@@ -526,56 +598,6 @@ func TestSampleBuilder(t *testing.T) {
 					time.Unix(1, 0),
 					3,
 				),
-			},
-		},
-		// Interval overlap handling.
-		{
-			name: "interval overlap handling",
-			series: seriesMap{
-				1: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1"),
-				2: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1"),
-			},
-			// Both instances map to the same monitored resource and will thus produce the same series.
-			metadata: promtest.MetadataMap{
-				"job1/instance1/metric1": &metadataEntry{Metric: "metric1", MetricType: textparse.MetricTypeCounter, ValueType: config.DOUBLE},
-			},
-			input: []record.RefSample{
-				// First sample for both series will define the reset timestamp.
-				{Ref: 1, T: 1000, V: 4},
-				{Ref: 2, T: 1500, V: 5},
-				// The sample for series 2 must be rejected.
-				{Ref: 1, T: 2000, V: 9},
-				{Ref: 2, T: 2500, V: 11},
-				// Both series get reset but the 2nd one is detected first.
-				// The emitted samples should flip over.
-				{Ref: 2, T: 3500, V: 3},
-				{Ref: 1, T: 3000, V: 2},
-			},
-			result: []*metric_pb.Metric{
-				nil, // Skipped by reset timestamp handling.
-				nil, // Skipped by reset timestamp handling.
-				DoubleCounterPoint(
-					Labels(
-						Label("instance", "instance1"),
-						Label("job", "job1"),
-					),
-					"metric1",
-					time.Unix(1, 0),
-					time.Unix(2, 0),
-					5,
-				),
-				nil, // Rejected because of overlap.
-				DoubleCounterPoint(
-					Labels(
-						Label("instance", "instance1"),
-						Label("job", "job1"),
-					),
-					"metric1",
-					time.Unix(3, 5e8-1e6),
-					time.Unix(3, 5e8),
-					3,
-				),
-				nil, // Rejected because of overlap.
 			},
 		},
 		// Customized metric prefix.
@@ -619,7 +641,17 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 1, T: 3000, V: 8},
 			},
 			result: []*metric_pb.Metric{
-				nil, // Skipped by reset timestamp handling.
+				DoubleCounterPoint(
+					Labels(
+						Label("a", "1"),
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1_total",
+					time.Unix(2, 0),
+					time.Unix(2, 0),
+					0,
+				),
 				DoubleCounterPoint(
 					Labels(
 						Label("a", "1"),
@@ -649,7 +681,17 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 1, T: 3000, V: 8},
 			},
 			result: []*metric_pb.Metric{
-				nil, // Skipped by reset timestamp handling.
+				DoubleCounterPoint(
+					Labels(
+						Label("a", "1"),
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(2, 0),
+					time.Unix(2, 0),
+					0,
+				),
 				DoubleCounterPoint(
 					Labels(
 						Label("a", "1"),
@@ -692,6 +734,7 @@ func TestSampleBuilder(t *testing.T) {
 		},
 		// Samples with a NaN value should be dropped.
 		{
+			name: "NaN value",
 			series: seriesMap{
 				1: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_count"),
 			},
@@ -699,23 +742,20 @@ func TestSampleBuilder(t *testing.T) {
 				"job1/instance1/metric1": &metadataEntry{Metric: "metric1_count", MetricType: textparse.MetricTypeSummary, ValueType: config.DOUBLE},
 			},
 			input: []record.RefSample{
-				// A first non-NaN sample is necessary to avoid false-positives, since the
-				// first result will always be nil due to reset timestamp handling.
-				{Ref: 1, T: 2000, V: 5},
 				{Ref: 1, T: 4000, V: math.NaN()},
 			},
 			result: []*metric_pb.Metric{
-				nil, // due to reset timestamp handling
 				nil, // due to NaN
 			},
 		},
-		// Samples with a NaN value should be dropped.
+		// Samples with a NaN value and a cumulative
 		{
+			name: "NaN and cumulative",
 			series: seriesMap{
-				1: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_count"),
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1"),
 			},
 			metadata: promtest.MetadataMap{
-				"job1/instance1/metric1": &metadataEntry{Metric: "metric1_count", MetricType: textparse.MetricTypeSummary, ValueType: config.DOUBLE},
+				"job1/instance1/metric1": &metadataEntry{Metric: "metric1", MetricType: textparse.MetricTypeCounter, ValueType: config.INT64},
 			},
 			input: []record.RefSample{
 				// A first non-NaN sample is necessary to avoid false-positives, since the
@@ -725,14 +765,23 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 1, T: 5000, V: 9},
 			},
 			result: []*metric_pb.Metric{
-				nil, // due to reset timestamp handling
+				IntCounterPoint(
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(2, 0),
+					time.Unix(2, 0),
+					0,
+				),
 				nil, // due to NaN
 				IntCounterPoint(
 					Labels(
 						Label("instance", "instance1"),
 						Label("job", "job1"),
 					),
-					"metric1_count",
+					"metric1",
 					time.Unix(2, 0),
 					time.Unix(5, 0),
 					4,

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -242,14 +242,12 @@ func TestSampleBuilder(t *testing.T) {
 					3.5,
 				),
 				DoubleCounterPoint( // 3: A reset
-					// Timestamp set to 1ms before the end time to avoid
-					// conflict, see (*seriesCache).getResetAdjusted().
 					Labels(
 						Label("instance", "instance1"),
 						Label("job", "job1"),
 					),
 					"metric2",
-					time.Unix(5, int64(-time.Millisecond)),
+					time.Unix(5, 0),
 					time.Unix(5, 0),
 					3,
 				),


### PR DESCRIPTION
In cases where the former code skips a point because the reset timestamp is not known, the sidecar will now output a zero value. This lets us avoid skipping these points, meaning a metric name will be seen earlier by the backend. 

Removes a metric counting these events. Removes a number of error conditions that were already unlikely.

Note: This creates a zero-width cumulative value, which is not strongly specified in OTLP. Stackdriver does not allow this condition. Speaking for Lightstep, this seems like a fine outcome.

Metric systems that dislike 0-width 0-value points may simply drop these points. @jmacd will track this work with the OTel metrics data model SIG, see https://github.com/open-telemetry/opentelemetry-proto/issues/292.
(LS-23350)