### PR TITLE
Report filtered and dropped points by metric_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - New metric `sidecar.points.produced` counts total points produced from the WAL. (#187)
+- `sidecar.metrics.invalid` includes explanation for all unreported metrics, labeled by `key_reason` and `metric_name`, now covers filtered points, metadata errors, and explainations from the server. (#191)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - New metric `sidecar.points.produced` counts total points produced from the WAL. (#187)
-- `sidecar.metrics.invalid` includes explanation for all unreported metrics, labeled by `key_reason` and `metric_name`, now covers filtered points, metadata errors, and explanations from the server. (#191)
+- `sidecar.metrics.failing` includes explanation for all unreported metrics, labeled by `key_reason` and `metric_name`, now covers filtered points, metadata errors, and explanations from the server. (#191)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - OTLP data points re-use Resource and InstrumentationLibrary (thus are smaller). (#182)
-- Counter reset events output zero values at the reset timestamp, instead of skipping points. (#190)
 - `sidecar.metrics.invalid` broadened to include non-validation failures, renamed `sidecar.metrics.failing`. (#188)
+- Counter reset events output zero values at the reset timestamp, instead of skipping points. (#190)
 
 ### Removed
 
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- Removed healthcheck metrics from telemetry traces
+- Removed healthcheck metrics from telemetry traces. (#184)
 
 ## [0.21.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.21.0) - 2021-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - New metric `sidecar.points.produced` counts total points produced from the WAL. (#187)
-- `sidecar.metrics.invalid` includes explanation for all unreported metrics, labeled by `key_reason` and `metric_name`, now covers filtered points, metadata errors, and explainations from the server. (#191)
+- `sidecar.metrics.invalid` includes explanation for all unreported metrics, labeled by `key_reason` and `metric_name`, now covers filtered points, metadata errors, and explanations from the server. (#191)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -462,10 +462,10 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.queue.shards | gauge | number of current shards, as set by the queue manager | |
 | sidecar.queue.size | gauge | number of samples (i.e., points) standing in a queue waiting to export | |
 | sidecar.series.defined | counter | number of series defined in the WAL | |
-| sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: various |
+| sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: metadata, validation |
 | sidecar.points.produced | counter | number of points read from the prometheus WAL | |
-| sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: various |
-| sidecar.points.filtered | counter | number of points skipped due to filters | |
+| sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: metadata, validation |
+| sidecar.points.skipped | counter | number of points skipped due to filters, max-point-age, etc. | |
 | sidecar.metadata.lookups | counter | number of calls to lookup metadata | `error`: true, false |
 | sidecar.series.current | gauge | number of series refs in the series cache | `status`: live, filtered, invalid |
 | sidecar.wal.size | gauge | size of the prometheus WAL | |

--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.series.dropped | counter | number of series or metrics dropped | `key_reason`: various |
 | sidecar.points.produced | counter | number of points read from the prometheus WAL | |
 | sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: various |
-| sidecar.points.skipped | counter | number of points skipped due to filters | |
-| sidecar.metadata.filtered | counter | number of calls to lookup metadata | `error`: true, false |
+| sidecar.points.filtered | counter | number of points skipped due to filters | |
+| sidecar.metadata.lookups | counter | number of calls to lookup metadata | `error`: true, false |
 | sidecar.series.current | gauge | number of series refs in the series cache | `status`: live, filtered, invalid |
 | sidecar.wal.size | gauge | size of the prometheus WAL | |
 | sidecar.wal.offset | gauge | current offset in the prometheus WAL | |

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Metrics from the subordinate process can help identify issues once the first met
 | sidecar.points.produced | counter | number of points read from the prometheus WAL | |
 | sidecar.points.dropped | counter | number of points dropped due to errors | `key_reason`: various |
 | sidecar.points.skipped | counter | number of points skipped due to filters | |
-| sidecar.metadata.lookups | counter | number of calls to lookup metadata | `error`: true, false |
+| sidecar.metadata.filtered | counter | number of calls to lookup metadata | `error`: true, false |
 | sidecar.series.current | gauge | number of series refs in the series cache | `status`: live, filtered, invalid |
 | sidecar.wal.size | gauge | size of the prometheus WAL | |
 | sidecar.wal.offset | gauge | current offset in the prometheus WAL | |

--- a/README.md
+++ b/README.md
@@ -330,6 +330,14 @@ writing to the OTLP destination.  These errors are returned using gRPC
 and logs.  See the `sidecar.metrics.failing` metric to diagnose validation 
 errors.
 
+#### Metadata errors
+
+The sidecar may encounter errors between itself and Prometheus,
+including failures to locate metadata about a targets that Prometheus
+no longer knows about.  Missing metadata, Prometheus API errors, and
+other forms of inconsistency are reported using
+`sidecar.metrics.failing` with `key_reason` and `metric_name` attributes.
+
 #### Resources
 
 Use the `--destination.attribute=KEY=VALUE` flag to add additional resource attributes to all exported timeseries.

--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"github.com/go-kit/kit/log"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/common"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/metadata"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/otlp"
@@ -13,10 +14,14 @@ type SidecarConfig struct {
 	ClientFactory otlp.StorageClientFactory
 	Monitor       *prometheus.Monitor
 	Logger        log.Logger
+
+	// InstanceId is a unique identifer for this process.
 	InstanceId    string
 	Matchers      [][]*labels.Matcher
 	MetricRenames map[string]string
 	MetadataCache *metadata.Cache
+
+	FailingReporter common.FailingReporter
 
 	config.MainConfig
 }

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -273,6 +273,8 @@ func TestSuperStackDump(t *testing.T) {
 		t.Errorf("execution error: %v", err)
 		return
 	}
+	timer := time.NewTimer(time.Second * 10)
+	defer timer.Stop()
 
 	var lock sync.Mutex
 	var diagSpans []*traces.ResourceSpans
@@ -287,6 +289,10 @@ func TestSuperStackDump(t *testing.T) {
 		defer lock.Unlock()
 		for {
 			select {
+			case <-timer.C:
+				t.Log("timeout waiting for spans")
+				t.FailNow()
+				return
 			case rs := <-ts.spans:
 				// Note: below searching for a stack dump and
 				// a few key strings, as a simple test.  TODO:

--- a/cmd/opentelemetry-prometheus-sidecar/validation_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/validation_test.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -208,8 +207,6 @@ outer:
 					}
 				}
 				invalid[reason+"/"+mname] = true
-			default:
-				fmt.Println("HOW ABOUT", name)
 			}
 			return nil
 		}, data)

--- a/cmd/opentelemetry-prometheus-sidecar/validation_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/validation_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -207,6 +208,8 @@ outer:
 					}
 				}
 				invalid[reason+"/"+mname] = true
+			default:
+				fmt.Println("HOW ABOUT", name)
 			}
 			return nil
 		}, data)

--- a/cmd/stresstest/main.go
+++ b/cmd/stresstest/main.go
@@ -92,7 +92,7 @@ func Main() bool {
 		Timeout:          scfg.Destination.Timeout.Duration,
 		RootCertificates: scfg.Security.RootCertificates,
 		Headers:          grpcMetadata.New(scfg.Destination.Headers),
-		FailingSet:       common.NewFailingSet(scfg.Logger),
+		FailingReporter:  common.NewFailingSet(scfg.Logger),
 	})
 
 	queueManager, _ := otlp.NewQueueManager(

--- a/common/failingset.go
+++ b/common/failingset.go
@@ -30,6 +30,11 @@ import (
 )
 
 type (
+	// FailingReporter is an interface for FailingSet
+	FailingReporter interface {
+		Set(reason, metricName string)
+	}
+
 	// FailingSet reports a set of gauges to describe failing data points.
 	FailingSet struct {
 		observer metric.Int64ValueObserver

--- a/common/instruments.go
+++ b/common/instruments.go
@@ -18,9 +18,9 @@ var (
 		metric.WithDescription("Number of points that could not be exported"),
 	)
 
-	FilteredPoints = sidecar.OTelMeterMust.NewInt64Counter(
-		config.FilteredPointsMetric,
-		metric.WithDescription("Number of points that were not recorded because of filters"),
+	SkippedPoints = sidecar.OTelMeterMust.NewInt64Counter(
+		config.SkippedPointsMetric,
+		metric.WithDescription("Number of points that were bypassed"),
 	)
 )
 

--- a/common/instruments.go
+++ b/common/instruments.go
@@ -18,9 +18,9 @@ var (
 		metric.WithDescription("Number of points that could not be exported"),
 	)
 
-	SkippedPoints = sidecar.OTelMeterMust.NewInt64Counter(
-		config.SkippedPointsMetric,
-		metric.WithDescription("Number of points that were skipped because of a filter"),
+	FilteredPoints = sidecar.OTelMeterMust.NewInt64Counter(
+		config.FilteredPointsMetric,
+		metric.WithDescription("Number of points that were not recorded because of filters"),
 	)
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,7 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 	DroppedSeriesMetric  = "sidecar.series.dropped"
 	ProducedPointsMetric = "sidecar.points.produced"
 	DroppedPointsMetric  = "sidecar.points.dropped"
-	FilteredPointsMetric = "sidecar.points.filtered"
+	SkippedPointsMetric  = "sidecar.points.skipped"
 	FailingMetricsMetric = "sidecar.metrics.failing"
 
 	OutcomeKey          = attribute.Key("outcome")

--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,7 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 	DroppedSeriesMetric  = "sidecar.series.dropped"
 	ProducedPointsMetric = "sidecar.points.produced"
 	DroppedPointsMetric  = "sidecar.points.dropped"
-	SkippedPointsMetric  = "sidecar.points.skipped"
+	FilteredPointsMetric = "sidecar.points.filtered"
 	FailingMetricsMetric = "sidecar.metrics.failing"
 
 	OutcomeKey          = attribute.Key("outcome")

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -95,7 +95,7 @@ type Client struct {
 	headers          grpcMetadata.MD
 	compressor       string
 	prometheus       config.PromConfig
-	invalidSet       *common.FailingSet
+	invalidSet       common.FailingReporter
 
 	conn *grpc.ClientConn
 }
@@ -109,7 +109,7 @@ type ClientConfig struct {
 	Headers          grpcMetadata.MD
 	Compressor       string
 	Prometheus       config.PromConfig
-	FailingSet       *common.FailingSet
+	FailingReporter  common.FailingReporter
 }
 
 // NewClient creates a new Client.
@@ -126,7 +126,7 @@ func NewClient(conf ClientConfig) *Client {
 		headers:          conf.Headers,
 		compressor:       conf.Compressor,
 		prometheus:       conf.Prometheus,
-		invalidSet:       conf.FailingSet,
+		invalidSet:       conf.FailingReporter,
 	}
 }
 

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -147,6 +147,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 		r.metadataGetter,
 		r.metricsPrefix,
 		jobInstanceMap,
+		nil, // @@@ TODO
 	)
 	go seriesCache.run(ctx)
 

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -64,6 +64,7 @@ func NewPrometheusReader(
 	metricsPrefix string,
 	maxPointAge time.Duration,
 	scrapeConfig []*promconfig.ScrapeConfig,
+	failingReporter common.FailingReporter,
 ) *PrometheusReader {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -80,6 +81,7 @@ func NewPrometheusReader(
 		metricsPrefix:        metricsPrefix,
 		maxPointAge:          maxPointAge,
 		scrapeConfig:         scrapeConfig,
+		failingReporter:      failingReporter,
 	}
 }
 
@@ -95,6 +97,7 @@ type PrometheusReader struct {
 	metricsPrefix        string
 	maxPointAge          time.Duration
 	scrapeConfig         []*promconfig.ScrapeConfig
+	failingReporter      common.FailingReporter
 }
 
 func (r *PrometheusReader) Next() {
@@ -147,7 +150,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 		r.metadataGetter,
 		r.metricsPrefix,
 		jobInstanceMap,
-		nil, // @@@ TODO
+		r.failingReporter,
 	)
 	go seriesCache.run(ctx)
 

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wal"
+	"github.com/stretchr/testify/require"
 	metric_pb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resource_pb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
@@ -201,6 +202,7 @@ func TestReader_Progress(t *testing.T) {
 		}, resourceMetric(s))
 	}
 
+	require.EqualValues(t, map[string]bool{}, failingSet)
 }
 
 func resourceMetric(m *metric_pb.Metric) *metric_pb.ResourceMetrics {
@@ -266,5 +268,4 @@ func TestHashSeries(t *testing.T) {
 			t.Fatalf("hash for different series did not change")
 		}
 	}
-
 }

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -92,7 +92,8 @@ func TestReader_Progress(t *testing.T) {
 		"job1/inst1/metric1": &config.MetadataEntry{Metric: "metric1", MetricType: textparse.MetricTypeGauge, Help: "help"},
 	}
 
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, nil)
+	failingSet := testFailingReporter{}
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, nil, failingSet)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -157,7 +158,8 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, nil)
+
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, nil, failingSet)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -478,6 +478,8 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 			return errors.Errorf("unexpected summary suffix %q", suffix)
 		}
 	case textparse.MetricTypeHistogram:
+		// Note: It's unclear why this branch does not check for allowed
+		// suffixes the way the Summary branch does. Should it?
 		ts.Name = c.getMetricName(c.metricsPrefix, baseMetricName)
 		ts.Kind = config.CUMULATIVE
 		ts.ValueType = config.DISTRIBUTION

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -158,14 +158,15 @@ func newSeriesCache(
 		logger = log.NewNopLogger()
 	}
 	sc := &seriesCache{
-		logger:          logger,
-		dir:             dir,
-		filters:         filters,
-		metaget:         metaget,
-		entries:         map[uint64]*seriesCacheEntry{},
-		metricsPrefix:   metricsPrefix,
-		renames:         renames,
-		jobInstanceMap:  jobInstanceMap,
+		logger:         logger,
+		dir:            dir,
+		filters:        filters,
+		metaget:        metaget,
+		entries:        map[uint64]*seriesCacheEntry{},
+		metricsPrefix:  metricsPrefix,
+		renames:        renames,
+		jobInstanceMap: jobInstanceMap,
+
 		failingReporter: failingReporter,
 	}
 

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	sidecar "github.com/lightstep/opentelemetry-prometheus-sidecar"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/common"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry/doevery"
@@ -73,6 +74,9 @@ type seriesCache struct {
 	jobInstanceMap map[string]string
 
 	currentSeriesObs metric.Int64UpDownSumObserver
+
+	// TODO: initialize me after #189 merges.
+	failingSet *common.FailingSet
 }
 
 type seriesCacheEntry struct {
@@ -90,6 +94,7 @@ type seriesCacheEntry struct {
 	// expressions.
 	lset labels.Labels
 
+	name   string
 	suffix string
 	hash   uint64
 
@@ -285,12 +290,12 @@ func (c *seriesCache) get(ctx context.Context, ref uint64) (*seriesCacheEntry, e
 
 	if e.shouldTryLookup() {
 		if err := c.lookup(ctx, ref); err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "name: %s", e.name)
 		}
 	}
 
 	if !e.populated() {
-		return nil, errSeriesMissingMetadata
+		return nil, errors.Wrapf(errSeriesMissingMetadata, "name: %s", e.name)
 	}
 
 	return e, nil
@@ -324,18 +329,22 @@ func (c *seriesCache) getResetAdjusted(e *seriesCacheEntry, t int64, v float64) 
 func (c *seriesCache) set(ctx context.Context, ref uint64, lset labels.Labels, maxSegment int) error {
 	exported := c.filters == nil || matchFilters(lset, c.filters)
 
+	name := lset.Get("__name__")
+
 	if !exported {
 		// We can forget these labels forever, don't care b/c
 		// they didn't match.  We'll keep this in our entries
 		// map so that we can distinguish dropped points from
 		// filtered points.
 		lset = nil
+		c.failingSet.Set("filtered", name)
 	}
 
 	c.mtx.Lock()
 	c.entries[ref] = &seriesCacheEntry{
 		maxSegment: maxSegment,
 		lset:       lset,
+		name:       name,
 	}
 	c.mtx.Unlock()
 	return c.lookup(ctx, ref)
@@ -356,11 +365,20 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 	c.mtx.Unlock()
 
 	if entry.lset == nil {
-		// in which case the entry did not match the filters
+		// in which case the entry did not match the filters.  it was
+		// added to failingSet in set().
 		return nil
 	}
 
-	defer seriesCacheLookupCounter.Add(ctx, 1, &retErr)
+	failedReason := "unknown"
+
+	defer func() {
+		seriesCacheLookupCounter.Add(ctx, 1, &retErr)
+		if retErr == nil {
+			return
+		}
+		c.failingSet.Set(failedReason, entry.name)
+	}()
 
 	entryLabels := copyLabels(entry.lset)
 
@@ -373,36 +391,39 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 	}
 
 	var (
-		metricName     = entry.lset.Get("__name__")
 		baseMetricName string
 		suffix         string
 		job            = entry.lset.Get("job")
 		instance       = entry.lset.Get(c.jobInstanceKey(job))
 	)
-	meta, err := c.metaget.Get(ctx, job, instance, metricName)
+	meta, err := c.metaget.Get(ctx, job, instance, entry.name)
 	if err != nil {
-		return errors.Wrap(err, "get metadata")
+		failedReason = "metadata_error"
+		return err
 	}
 
 	if meta == nil {
 		// The full name didn't turn anything up. Check again in case it's a summary,
 		// histogram, or counter without the metric name suffix.
 		var ok bool
-		if baseMetricName, suffix, ok = stripComplexMetricSuffix(metricName); ok {
+		if baseMetricName, suffix, ok = stripComplexMetricSuffix(entry.name); ok {
 			meta, err = c.metaget.Get(ctx, job, instance, baseMetricName)
 			if err != nil {
-				return errors.Wrap(err, "get metadata")
+				failedReason = "metadata_error"
+				return err
 			}
 		}
 		if meta == nil {
 			doevery.TimePeriod(config.DefaultNoisyLogPeriod, func() {
 				level.Warn(c.logger).Log(
 					"msg", "metadata not found",
-					"metric_name", metricName,
-					"labels", fmt.Sprint(entry.lset),
+					"metric_name", entry.name,
+					"job", job,
+					"instance", instance,
 				)
 			})
-			return nil
+			failedReason = "metadata_missing"
+			return errSeriesMissingMetadata
 		}
 	}
 	// Handle label modifications for histograms early so we don't build the label map twice.
@@ -417,7 +438,7 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 	}
 
 	ts := tsDesc{
-		Name:   c.getMetricName(c.metricsPrefix, metricName),
+		Name:   c.getMetricName(c.metricsPrefix, entry.name),
 		Labels: entryLabels,
 	}
 	sort.Sort(&ts.Labels)
@@ -453,13 +474,15 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 			// Note: this branch has been seen for a
 			// _bucket suffix, indicating a mix of
 			// histogram and summary conventions.
-			return errors.Errorf("unexpected summary metric name suffix %q", suffix)
+			failedReason = "invalid_suffix"
+			return errors.Errorf("unexpected summary suffix %q", suffix)
 		}
 	case textparse.MetricTypeHistogram:
 		ts.Name = c.getMetricName(c.metricsPrefix, baseMetricName)
 		ts.Kind = config.CUMULATIVE
 		ts.ValueType = config.DISTRIBUTION
 	default:
+		failedReason = "unknown_type"
 		return errors.Errorf("unexpected metric type %s", meta.MetricType)
 	}
 

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	sidecar "github.com/lightstep/opentelemetry-prometheus-sidecar"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/common"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/config"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry"
 	"github.com/lightstep/opentelemetry-prometheus-sidecar/telemetry/doevery"
@@ -52,10 +53,6 @@ type seriesGetter interface {
 	getResetAdjusted(entry *seriesCacheEntry, timestamp int64, value float64) (reset int64, adjusted float64)
 }
 
-type failingReporter interface {
-	Set(reason, metricName string)
-}
-
 // seriesCache holds a mapping from series reference to label set.
 // It can garbage collect obsolete entries based on the most recent WAL checkpoint.
 // Implements seriesGetter.
@@ -79,7 +76,7 @@ type seriesCache struct {
 	currentSeriesObs metric.Int64UpDownSumObserver
 
 	// TODO: initialize me after #189 merges.
-	failingReporter failingReporter
+	failingReporter common.FailingReporter
 }
 
 type seriesCacheEntry struct {
@@ -156,7 +153,7 @@ func newSeriesCache(
 	metaget MetadataGetter,
 	metricsPrefix string,
 	jobInstanceMap map[string]string,
-	failingReporter failingReporter,
+	failingReporter common.FailingReporter,
 ) *seriesCache {
 	if logger == nil {
 		logger = log.NewNopLogger()

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -75,7 +75,6 @@ type seriesCache struct {
 
 	currentSeriesObs metric.Int64UpDownSumObserver
 
-	// TODO: initialize me after #189 merges.
 	failingReporter common.FailingReporter
 }
 

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -418,8 +418,7 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 				level.Warn(c.logger).Log(
 					"msg", "metadata not found",
 					"metric_name", entry.name,
-					"job", job,
-					"instance", instance,
+					"labels", fmt.Sprint(entry.lset),
 				)
 			})
 			failedReason = "metadata_missing"

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -166,6 +166,8 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 	if b.maxPointAge > 0 {
 		when := time.Unix(sample.T/1000, int64(time.Duration(sample.T%1000)*time.Millisecond))
 		if time.Since(when) > b.maxPointAge {
+			// Note: Counts as a skipped point (as if
+			// filtered out), not a dropped point.
 			return nil, 0, tailSamples, nil
 		}
 	}

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -381,9 +381,10 @@ func (s *Supervisor) noteHealthy(hr health.Response) string {
 		summary = append(summary, "msg", "sidecar is running")
 
 		summary = append(summary, hr.MetricLogSummary(config.ProducedPointsMetric)...)
-		summary = append(summary, hr.MetricLogSummary(config.OutcomeMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedSeriesMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedPointsMetric)...)
+		summary = append(summary, hr.MetricLogSummary(config.FilteredPointsMetric)...)
+		summary = append(summary, hr.MetricLogSummary(config.OutcomeMetric)...)
 	}
 
 	level.Info(s.logger).Log(summary...)

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -383,7 +383,7 @@ func (s *Supervisor) noteHealthy(hr health.Response) string {
 		summary = append(summary, hr.MetricLogSummary(config.ProducedPointsMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedSeriesMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.DroppedPointsMetric)...)
-		summary = append(summary, hr.MetricLogSummary(config.FilteredPointsMetric)...)
+		summary = append(summary, hr.MetricLogSummary(config.SkippedPointsMetric)...)
 		summary = append(summary, hr.MetricLogSummary(config.OutcomeMetric)...)
 	}
 


### PR DESCRIPTION
Adds coverage of skipped points and dropped points to `sidecar.metrics.failing`, including a metric name label. This improves error messaging to include the metric name in the logs too.

Note that metadata-missing conditions were not being counted as dropped points, so this fixes a minor discrepancy. This is seen as a `nil` return from `(*seriesCache).lookup()` following metadata lookup failure changing to a not-found error, thus how those conditions were counted.

Resolves #44. (LS-23103)