### PR TITLE
Send Summary points in their respective OTLP Summary representation.

### DIFF
--- a/internal/otlptest/otlptest.go
+++ b/internal/otlptest/otlptest.go
@@ -242,6 +242,52 @@ func DoubleHistogramCumulative(name, desc, unit string, idps ...*otlpmetrics.Dou
 	}
 }
 
+type DoubleSummaryQuantileValueStruct struct {
+	Quantile float64
+	Value    float64
+}
+
+func DoubleSummaryQuantileValue(quantile, value float64) DoubleSummaryQuantileValueStruct {
+	return DoubleSummaryQuantileValueStruct{
+		Quantile: quantile,
+		Value   : value,
+	}
+}
+
+func DoubleSummaryDataPoint(labels []*otlpcommon.StringKeyValue, start, end time.Time, sum float64, count uint64, quantiles ...DoubleSummaryQuantileValueStruct) *otlpmetrics.DoubleSummaryDataPoint {
+	quantileValues := make([]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile, 0, len(quantiles))
+	for _, value := range quantiles {
+		quantileValues = append(quantileValues, &otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{
+			Quantile: value.Quantile,
+			Value:    value.Value,
+		})
+	}
+	return &otlpmetrics.DoubleSummaryDataPoint{
+		Labels:            labels,
+		StartTimeUnixNano: uint64(start.UnixNano()),
+		TimeUnixNano:      uint64(end.UnixNano()),
+		Sum:               sum,
+		Count:             count,
+		QuantileValues:    quantileValues,
+	}
+}
+
+func DoubleSummary(name, desc, unit string, dps ...*otlpmetrics.DoubleSummaryDataPoint) *otlpmetrics.Metric {
+	if len(dps) == 0 {
+		dps = []*otlpmetrics.DoubleSummaryDataPoint{}
+	}
+	return &otlpmetrics.Metric{
+		Name:        name,
+		Description: desc,
+		Unit:        unit,
+		Data: &otlpmetrics.Metric_DoubleSummary{
+			DoubleSummary: &otlpmetrics.DoubleSummary{
+				DataPoints: dps,
+			},
+		},
+	}
+}
+
 // Visitor is used because it takes around 50 lines of code to
 // traverse an OTLP request, with looping over Resource,
 // Instrumentation Library, the list of Metrics, and six distinct

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -494,22 +494,9 @@ func (c *seriesCache) lookup(ctx context.Context, ref uint64) (retErr error) {
 			ts.ValueType = meta.ValueType
 		}
 	case textparse.MetricTypeSummary:
-		switch suffix {
-		case metricSuffixSum:
-			ts.Kind = config.CUMULATIVE
-			ts.ValueType = config.DOUBLE
-		case metricSuffixCount:
-			ts.Kind = config.CUMULATIVE
-			ts.ValueType = config.INT64
-		case "": // Actual quantiles.
-			ts.Kind = config.GAUGE
-			ts.ValueType = config.DOUBLE
-		default:
-			// Note: this branch has been seen for a
-			// _bucket suffix, indicating a mix of
-			// histogram and summary conventions.
-			return errors.Errorf("unexpected summary metric name suffix %q", suffix)
-		}
+		ts.Name = c.getMetricName(c.metricsPrefix, baseMetricName)
+		ts.Kind = config.CUMULATIVE
+		ts.ValueType = config.DOUBLE
 	case textparse.MetricTypeHistogram:
 		ts.Name = c.getMetricName(c.metricsPrefix, baseMetricName)
 		ts.Kind = config.CUMULATIVE

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -330,7 +330,7 @@ Loop:
 		}
 		lastTimestamp = s.T
 
-		rt, v, ok := b.series.getResetAdjusted(s.Ref, s.T, s.V)
+		rt, v := b.series.getResetAdjusted(e, s.T, s.V)
 
 		switch e.suffix {
 		case metricSuffixSum:
@@ -353,11 +353,6 @@ Loop:
 			})
 		default:
 			break Loop
-		}
-		// If a series appeared for the first time, we won't get a valid reset timestamp yet.
-		// We skip the entire summary sample in this case.
-		if !ok {
-			skip = true
 		}
 		consumed++
 	}

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -38,6 +38,7 @@ const (
 
 var (
 	errHistogramMetadataMissing = errors.New("histogram metadata missing")
+	errSummaryMetadataMissing    = errors.New("summary metadata missing")
 )
 
 // Appender appends a time series with exactly one data point. A hash for the series
@@ -117,31 +118,26 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 		}
 
 	case textparse.MetricTypeSummary:
-		switch entry.suffix {
-		case metricSuffixSum:
-			var value float64
-			resetTimestamp, value, ok = b.series.getResetAdjusted(sample.Ref, sample.T, sample.V)
-			if !ok {
-				return nil, 0, tailSamples, nil
-			}
-			point.Data = &metric_pb.Metric_DoubleSum{
-				DoubleSum: monotonicDoublePoint(labels, resetTimestamp, sample.T, value),
-			}
-		case metricSuffixCount:
-			var value float64
-			resetTimestamp, value, ok = b.series.getResetAdjusted(sample.Ref, sample.T, sample.V)
-			if !ok {
-				return nil, 0, tailSamples, nil
-			}
-			point.Data = &metric_pb.Metric_IntSum{
-				IntSum: monotonicIntegerPoint(labels, resetTimestamp, sample.T, value),
-			}
-		case "": // Actual quantiles.
-			point.Data = &metric_pb.Metric_DoubleGauge{
-				DoubleGauge: doubleGauge(labels, sample.T, sample.V),
-			}
-		default:
-			return nil, 0, tailSamples, errors.Errorf("unexpected metric name suffix %q", entry.suffix)
+		// We pass in the original lset for matching since Prometheus's target label must
+		// be the same as well.
+		var value *metric_pb.DoubleSummaryDataPoint
+		value, resetTimestamp, tailSamples, err = b.buildSummary(ctx, entry.metadata.Metric, entry.lset, samples)
+		if value == nil || err != nil {
+			return nil, 0, tailSamples, err
+		}
+
+		value.Labels = labels
+		value.StartTimeUnixNano = getNanos(resetTimestamp)
+		value.TimeUnixNano = getNanos(sample.T)
+
+		doubleSummary := &metric_pb.DoubleSummary{
+			DataPoints: []*metric_pb.DoubleSummaryDataPoint{
+				value,
+			},
+		}
+
+		point.Data = &metric_pb.Metric_DoubleSummary{
+			DoubleSummary: doubleSummary,
 		}
 
 	case textparse.MetricTypeHistogram:
@@ -287,6 +283,110 @@ func (d *distribution) Swap(i, j int) {
 	d.values[i], d.values[j] = d.values[j], d.values[i]
 }
 
+// buildSummary consumes series from the beginning of the input slice that belong to a summary
+// with the given metric name and label set.
+// It returns the reset timestamp along with the summary.
+// NOTE: buildSummary() EXTENSIVELY mimics the logic of buildHistogram() - consider refactoring (properly).
+func (b *sampleBuilder) buildSummary(
+	ctx context.Context,
+	baseName string,
+	matchLset labels.Labels,
+	samples []record.RefSample,
+) (*metric_pb.DoubleSummaryDataPoint, int64, []record.RefSample, error) {
+	var (
+		consumed       int
+		count, sum     float64
+		resetTimestamp int64
+		lastTimestamp  int64
+		values	       = make([]*metric_pb.DoubleSummaryDataPoint_ValueAtQuantile, 0)
+		skip           = false
+	)
+	// We assume that all series belonging to the summary are sequential. Consume series
+	// until we hit a new metric.
+Loop:
+	for i, s := range samples {
+		e, err := b.series.get(ctx, s.Ref)
+		if err != nil {
+			// Note: This case may or may not trigger the
+			// len(samples) == len(newSamples) test in
+			// manager.go. The important part here is that
+			// we may skip or may not skip any points that
+			// belong to the histogram, but if we don't
+			// the manager safetly advances.
+			return nil, 0, samples, err
+		}
+		if e == nil {
+			// These points were filtered. This seems like
+			// an impossible situation.
+			break
+		}
+		name := e.lset.Get("__name__")
+		// The series matches if it has the same base name, the remainder is a valid summary suffix,
+		// and the labels aside from the `quantile` and __name__ label match up.
+		if !strings.HasPrefix(name, baseName) || !labelsEqual(e.lset, matchLset, "quantile") {
+			break
+		}
+		// In general, a scrape cannot contain the same (set of) series repeatedlty but for different timestamps.
+		// It could still happen with bad clients though and we are doing it in tests for simplicity.
+		// If we detect the same series as before but for a different timestamp, return the summary up to this
+		// series and leave the duplicate time series untouched on the input.
+		if i > 0 && s.T != lastTimestamp {
+			// TODO: counter
+			break
+		}
+		lastTimestamp = s.T
+
+		rt, v, ok := b.series.getResetAdjusted(s.Ref, s.T, s.V)
+
+		switch e.suffix {
+		case metricSuffixSum:
+			sum = v
+		case metricSuffixCount:
+			count = v
+			// We take the count series as the authoritative source for the overall reset timestamp.
+			resetTimestamp = rt
+		case "": // Actual values at quantiles.
+			quantile, err := strconv.ParseFloat(e.lset.Get("quantile"), 64)
+
+			if err != nil {
+				consumed++
+				// TODO: increment metric.
+				continue
+			}
+			values = append(values, &metric_pb.DoubleSummaryDataPoint_ValueAtQuantile{
+				Quantile: quantile,
+				Value: v,
+			})
+		default:
+			break Loop
+		}
+		// If a series appeared for the first time, we won't get a valid reset timestamp yet.
+		// We skip the entire summary sample in this case.
+		if !ok {
+			skip = true
+		}
+		consumed++
+	}
+	// Don't emit a sample if we explicitly skip it or no reset timestamp was set because the
+	// count series was missing.
+	if skip || resetTimestamp == 0 {
+		// TODO add a counter for this event.
+		if consumed == 0 {
+			// This may be caused by a change of metadata or metadata conflict.
+			// There was no "quantile" label, or there was no _sum or _count suffix.
+			return nil, 0, samples[1:], errSummaryMetadataMissing
+		}
+		return nil, 0, samples[consumed:], nil
+	}
+
+	summary := &metric_pb.DoubleSummaryDataPoint{
+		Count:		uint64(count),
+		Sum:		sum,
+		QuantileValues: values,
+	}
+	return summary, resetTimestamp, samples[consumed:], nil
+}
+
 // buildHistogram consumes series from the beginning of the input slice that belong to a histogram
 // with the given metric name and label set.
 // It returns the reset timestamp along with the distrubution.
@@ -326,7 +426,7 @@ Loop:
 		name := e.lset.Get("__name__")
 		// The series matches if it has the same base name, the remainder is a valid histogram suffix,
 		// and the labels aside from the le and __name__ label match up.
-		if !strings.HasPrefix(name, baseName) || !histogramLabelsEqual(e.lset, matchLset) {
+		if !strings.HasPrefix(name, baseName) || !labelsEqual(e.lset, matchLset, "le") {
 			break
 		}
 		// In general, a scrape cannot contain the same (set of) series repeatedlty but for different timestamps.
@@ -410,16 +510,16 @@ Loop:
 	return histogram, resetTimestamp, samples[consumed:], nil
 }
 
-// histogramLabelsEqual checks whether two label sets for a histogram series are equal aside from their
-// le and __name__ labels.
-func histogramLabelsEqual(a, b labels.Labels) bool {
+// labelsEqual checks whether two label sets for a series are equal aside from a specified
+// common label and __name__.
+func labelsEqual(a, b labels.Labels, commonLabel string) bool {
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
-		if a[i].Name == "le" || a[i].Name == "__name__" {
+		if a[i].Name == commonLabel || a[i].Name == "__name__" {
 			i++
 			continue
 		}
-		if b[j].Name == "le" || b[j].Name == "__name__" {
+		if b[j].Name == commonLabel || b[j].Name == "__name__" {
 			j++
 			continue
 		}
@@ -429,16 +529,16 @@ func histogramLabelsEqual(a, b labels.Labels) bool {
 		i++
 		j++
 	}
-	// Consume trailing le and __name__ labels so the check below passes correctly.
+	// Consume trailing common and __name__ labels so the check below passes correctly.
 	for i < len(a) {
-		if a[i].Name == "le" || a[i].Name == "__name__" {
+		if a[i].Name == commonLabel || a[i].Name == "__name__" {
 			i++
 			continue
 		}
 		break
 	}
 	for j < len(b) {
-		if b[j].Name == "le" || b[j].Name == "__name__" {
+		if b[j].Name == commonLabel || b[j].Name == "__name__" {
 			j++
 			continue
 		}

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -465,6 +465,19 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 7, T: 1000, V: 3},
 			},
 			result: []*metric_pb.Metric{
+				DoubleSummaryPoint( // 0:
+					Labels(
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(1, 0),
+					time.Unix(1, 0),
+					0,
+					0,
+					DoubleSummaryQuantileValue(0.5, 0),
+					DoubleSummaryQuantileValue(0.9, 0),
+				),
 				DoubleSummaryPoint( // 1:
 					Labels(
 						Label("instance", "instance1"),
@@ -478,7 +491,18 @@ func TestSampleBuilder(t *testing.T) {
 					DoubleSummaryQuantileValue(0.5, float64(0.7) - float64(0.3)),
 					DoubleSummaryQuantileValue(0.9, float64(0.8) - float64(0.6)),
 				),
-				nil, // 2: skipped
+				DoubleSummaryPoint( // 2: summary w/ no quantile values
+					Labels(
+						Label("a", "b"),
+						Label("instance", "instance1"),
+						Label("job", "job1"),
+					),
+					"metric1",
+					time.Unix(1, 0),
+					time.Unix(1, 0),
+					0,
+					0,
+				),
 				DoubleSummaryPoint( // 3: summary w/ no quantile values
 					Labels(
 						Label("a", "b"),
@@ -796,7 +820,7 @@ func TestSampleBuilder(t *testing.T) {
 					0,
 				),
 				nil, // due to NaN
-				DoubleSummaryPoint(
+				IntCounterPoint(
 					Labels(
 						Label("instance", "instance1"),
 						Label("job", "job1"),
@@ -804,7 +828,6 @@ func TestSampleBuilder(t *testing.T) {
 					"metric1",
 					time.Unix(2, 0),
 					time.Unix(5, 0),
-					0,
 					4,
 				),
 			},


### PR DESCRIPTION
Fixes #149 

Before we were sending them as a individual metric series/points,
but there's no need to these days.
