### PR TITLE
don't skip segments, restart reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Observability: new metrics `sidecar.refs.collected` and `sidecar.refs.notfound` count series references removed in garbage collection and not found during lookup. (#203)
 - Added a loop at the start of `Tail` to wait in the event that prometheus is writing a new checkpoint. The max period for this loop is 5m0s (#205)
 - Add proper support for Summary (#207)
+- Instead of skipping segments, restart the prometheus reader to ensure we don't miss series references.
 
 ## [0.22.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.22.0) - 2021-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Observability: new metrics `sidecar.refs.collected` and `sidecar.refs.notfound` count series references removed in garbage collection and not found during lookup. (#203)
 - Added a loop at the start of `Tail` to wait in the event that prometheus is writing a new checkpoint. The max period for this loop is 5m0s (#205)
 - Add proper support for Summary (#207)
-- Instead of skipping segments, restart the prometheus reader to ensure we don't miss series references.
+- Instead of skipping segments, restart the prometheus reader to ensure we don't miss series references. (#227)
 
 ## [0.22.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.22.0) - 2021-04-16
 


### PR DESCRIPTION
It's possible for the sidecar to fall behind to a point where segments have been deleted before it has a chance to process them. We used to skip the segments in order to catch up, but the right thing to do is for the Tail to re-read the checkpoint. Skipped segments could contain series records which the sidecar won't have moving forward if we just skip the missing segments. That data will be in the checkpoint though.