### PR TITLE
Do not count staleness markers as skipped points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added a loop at the start of `Tail` to wait in the event that prometheus is writing a new checkpoint. The max period for this loop is 5m0s (#205)
 - Add proper support for Summary (#207)
 - Keep existing shards during re-sharding events. (#221)
-- Instead of skipping segments, restart the prometheus reader to ensure we don't miss series references. (#227)
+- Instead of skipping segments, restart the Prometheus reader to ensure we don't miss series references. (#227)
+- Do not count Prometheus staleness markers as skipped points. (#231)
 
 ## [0.22.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.22.0) - 2021-04-16
 

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -38,7 +38,8 @@ const (
 
 var (
 	errHistogramMetadataMissing = errors.New("histogram metadata missing")
-	errSummaryMetadataMissing = errors.New("summary metadata missing")
+	errSummaryMetadataMissing   = errors.New("summary metadata missing")
+	errStalenessMarkerSkipped   = errors.New("staleness marker skipped")
 )
 
 // Appender appends a time series with exactly one data point.
@@ -65,7 +66,7 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 	if math.IsNaN(sample.V) {
 		// Note: This includes stale markers, which are
 		// specific NaN values defined in prometheus/tsdb.
-		return nil, tailSamples, nil
+		return nil, tailSamples, errStalenessMarkerSkipped
 	}
 
 	entry, err := b.series.get(ctx, sample.Ref)
@@ -116,6 +117,9 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 		var value *metric_pb.DoubleSummaryDataPoint
 		value, resetTimestamp, tailSamples, err = b.buildSummary(ctx, entry.metadata.Metric, entry.lset, samples)
 		if value == nil || err != nil {
+			if err == nil {
+				err = errSummaryMetadataMissing
+			}
 			return nil, tailSamples, err
 		}
 
@@ -140,6 +144,9 @@ func (b *sampleBuilder) next(ctx context.Context, samples []record.RefSample) (*
 		var value *metric_pb.DoubleHistogramDataPoint
 		value, resetTimestamp, tailSamples, err = b.buildHistogram(ctx, entry.metadata.Metric, entry.lset, samples)
 		if value == nil || err != nil {
+			if err == nil {
+				err = errHistogramMetadataMissing
+			}
 			return nil, tailSamples, err
 		}
 
@@ -289,7 +296,7 @@ func (b *sampleBuilder) buildSummary(
 		count, sum     float64
 		resetTimestamp int64
 		lastTimestamp  int64
-		values	       = make([]*metric_pb.DoubleSummaryDataPoint_ValueAtQuantile, 0)
+		values         = make([]*metric_pb.DoubleSummaryDataPoint_ValueAtQuantile, 0)
 	)
 	// We assume that all series belonging to the summary are sequential. Consume series
 	// until we hit a new metric.
@@ -350,7 +357,7 @@ Loop:
 			}
 			values = append(values, &metric_pb.DoubleSummaryDataPoint_ValueAtQuantile{
 				Quantile: quantile,
-				Value: v,
+				Value:    v,
 			})
 		default:
 			break Loop
@@ -370,8 +377,8 @@ Loop:
 	}
 
 	summary := &metric_pb.DoubleSummaryDataPoint{
-		Count:		uint64(count),
-		Sum:		sum,
+		Count:          uint64(count),
+		Sum:            sum,
 		QuantileValues: values,
 	}
 	return summary, resetTimestamp, samples[consumed:], nil


### PR DESCRIPTION
These were being counted in `sidecar.points.skipped`, which they should not. This points at need to (a) keep track of "reset" timestamps for gauges, (b) force gaps into the series for staleness markers (TODO).