### PR TITLE
Adding ability to set prometheus version

### DIFF
--- a/.github/workflows/staging-approval-public.yml
+++ b/.github/workflows/staging-approval-public.yml
@@ -65,8 +65,11 @@ jobs:
         echo IMAGE_TAG is $IMAGE_TAG
 
     - name: debug
+      env:
+        PROMETHEUS_VERSION: ${{ secrets.PROMETHEUS_VERSION }}
       run: |
         echo IMAGE_TAG is $IMAGE_TAG
+        echo PROMETHEUS_VERSION is $PROMETHEUS_VERSION
 
     - name: codefresh-pipeline-runner
       uses: codefresh-io/codefresh-pipeline-runner@v7
@@ -75,7 +78,7 @@ jobs:
         CF_API_KEY: ${{ secrets.CODEFRESH_API_TOKEN }}
       id: run-pipeline
       with:
-        args: -v IMAGE_TAG=${{ env.IMAGE_TAG }}
+        args: -v IMAGE_TAG=${{ env.IMAGE_TAG }} -v PROMETHEUS_VERSION=${{ secrets.PROMETHEUS_VERSION }}
 
 #------------------------------------------------------------------
 
@@ -101,8 +104,11 @@ jobs:
         echo IMAGE_TAG is $IMAGE_TAG
 
     - name: debug
+      env:
+        PROMETHEUS_VERSION: ${{ secrets.PROMETHEUS_VERSION }}
       run: |
         echo IMAGE_TAG is $IMAGE_TAG
+        echo PROMETHEUS_VERSION is $PROMETHEUS_VERSION
 
     - name: codefresh-pipeline-runner
       uses: codefresh-io/codefresh-pipeline-runner@v7
@@ -111,6 +117,6 @@ jobs:
         CF_API_KEY: ${{ secrets.CODEFRESH_API_TOKEN }}
       id: run-pipeline
       with:
-        args: -v IMAGE_TAG=${{ env.IMAGE_TAG }}
+        args: -v IMAGE_TAG=${{ env.IMAGE_TAG }} -v PROMETHEUS_VERSION=${{ secrets.PROMETHEUS_VERSION }}
 
 


### PR DESCRIPTION
This change allows setting of the Prometheus version using an external Github env var (settings > secrets > PROMETHEUS_VERSION)