### PR TITLE
fix issue w/ nextSegment being set incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Add `sidecar.series.current` to the periodic supervisor log. (#236)
+- Fix issue w/ nextSegment being set incorrectly. (#242)
 
 ## [0.23.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.0) - 2021-04-23
 

--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -62,6 +62,7 @@ func StartComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTai
 			//
 			// NOTE: this case *should* never happen
 			if currentSegment > tailer.CurrentSegment() {
+				_ = level.Warn(scfg.Logger).Log("msg", "unexpected segment truncation", "currentSegment", err, "tailer.CurrentSegment", tailer.CurrentSegment())
 				tailer.SetNextSegment(currentSegment + 1)
 				startOffset = currentSegment * wal.DefaultSegmentSize
 			}

--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -52,12 +52,20 @@ func StartComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTai
 				break
 			}
 			attempts += 1
-			// SetCurrentSegment is being called here to ensure that the tailer
-			// is able to continue past truncated logs after initialization
-			// this addresses the case where a segment is detected as truncated
-			// and its reason for being truncated is *not* a checkpoint happening
-			tailer.SetCurrentSegment(currentSegment)
-			startOffset = currentSegment * wal.DefaultSegmentSize
+			// The following check is to ensure that if a sidecar error'd on
+			// a truncated segment and the truncation was *not* due to a checkpoint,
+			// that truncated segment is skipped when the reader is restart. Otherwise
+			// the reader will reset nextSegment to the next segment after the
+			// checkpoint and hit the same truncated file. NOTE: if the truncation
+			// was caused by a checkpoint, we shouldn't do anything and let the
+			// reader continue on.
+			//
+			// NOTE: this case *should* never happen
+			if currentSegment > tailer.CurrentSegment() {
+				tailer.SetNextSegment(currentSegment + 1)
+				startOffset = currentSegment * wal.DefaultSegmentSize
+			}
+
 			continue
 		}
 		break

--- a/cmd/internal/start_components_test.go
+++ b/cmd/internal/start_components_test.go
@@ -15,6 +15,7 @@ import (
 type fakeTailer struct {
 	readError error
 	sizeError error
+	next      int
 }
 
 func (t *fakeTailer) Size() (int, error) {
@@ -33,14 +34,15 @@ func (t *fakeTailer) Close() error {
 }
 
 func (t *fakeTailer) CurrentSegment() int {
-	return 0
+	return t.next
 }
 
 func (t *fakeTailer) Read(b []byte) (int, error) {
 	return 0, t.readError
 }
 
-func (t *fakeTailer) SetCurrentSegment(int) {
+func (t *fakeTailer) SetNextSegment(next int) {
+	t.next = next
 }
 
 var _ tail.WalTailer = &fakeTailer{}

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -91,7 +91,7 @@ type WalTailer interface {
 	Close() error
 	CurrentSegment() int
 	Read(b []byte) (int, error)
-	SetCurrentSegment(int)
+	SetNextSegment(int)
 }
 
 // Tailer tails a write ahead log in a given directory.
@@ -334,10 +334,10 @@ func (t *Tailer) getCurrentSegment() int {
 // Offset is reset as in incNextSegment()
 // as we *just* started pointing to the *current*
 // segment.
-func (t *Tailer) SetCurrentSegment(segment int) {
+func (t *Tailer) SetNextSegment(segment int) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.nextSegment = segment + 1
+	t.nextSegment = segment
 	t.offset = 0
 }
 


### PR DESCRIPTION
The Tailer returns `ErrSkipSegment` in two different scenarios.
1. The reader hits a truncated wal segment because a checkpoint is happening
2. The reader hits a truncated wal segment for any other reason

v0.23.0 introduced a bug where the `nextSegment` could be set incorrectly in case number 1. This PR checks that `currentSegment` is ahead of the Tailer's `nextSegment` before setting it.