### PR TITLE
Rename `--prometheus.max-shards` to `--opentelemetry.max-shards` for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `sidecar.series.current` to the periodic supervisor log. (#236)
 - Assemble multiple points per Metric, limit requests by size instead of points. (#237)
-- Replace `--prometheus.max-timeseries-per-request` with `--opentelemetry.max-bytes-per-request`, default 64kB (yaml: `prometheus:\nmax_timeseries_per_request:` with `opentelemetry:\nmax_bytes_per_request:`)  (#237)
+- Rename `--prometheus.max-timeseries-per-request` flag to `--opentelemetry.max-bytes-per-request`, default 64kB (#237)
+- Rename `prometheus: max_timeseries_per_request:` yaml to `opentelemetry: max_bytes_per_request:` (#237)
 - Fix issue w/ nextSegment being set incorrectly. (#242)
+- Rename `--prometheus.max-shards` to `--opentelemetry.max-shards` ()
+- Rename `prometheus: max_shards:` yaml to `opentelemetry: max_shards:` ()
+- Rename `--prometheus.min-shards` to `--opentelemetry.min-shards` ()
+- Rename `prometheus: min-shards:` yaml to `opentelemetry: min_shards:` ()
 
 ## [0.23.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.0) - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Assemble multiple points per Metric, limit requests by size instead of points. (#237)
+- Replace `--prometheus.max-timeseries-per-request` flag with `--opentelemetry.max-bytes-per-request`, default 64kB
+- Rename `--prometheus.max-shards` to `--opentelemetry.max-shards` (#245)
+- Rename `--prometheus.min-shards` to `--opentelemetry.min-shards` (#245)
+
 ## [0.23.1](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.1) - 2021-05-03
 
 ### Changed
 
 - Add `sidecar.series.current` to the periodic supervisor log. (#236)
-- Assemble multiple points per Metric, limit requests by size instead of points. (#237)
-- Rename `--prometheus.max-timeseries-per-request` flag to `--opentelemetry.max-bytes-per-request`, default 64kB (#237)
-- Rename `prometheus: max_timeseries_per_request:` yaml to `opentelemetry: max_bytes_per_request:` (#237)
 - Fix issue w/ nextSegment being set incorrectly. (#242)
-- Rename `--prometheus.max-shards` to `--opentelemetry.max-shards` ()
-- Rename `prometheus: max_shards:` yaml to `opentelemetry: max_shards:` ()
-- Rename `--prometheus.min-shards` to `--opentelemetry.min-shards` ()
-- Rename `prometheus: min-shards:` yaml to `opentelemetry: min_shards:` ()
 
 ## [0.23.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.0) - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 - Assemble multiple points per Metric, limit requests by size instead of points. (#237)
-- Replace `--prometheus.max-timeseries-per-request` flag with `--opentelemetry.max-bytes-per-request`, default 64kB
+- Replace `--prometheus.max-timeseries-per-request` flag with `--opentelemetry.max-bytes-per-request` with 64kB default size (#237)
 - Rename `--prometheus.max-shards` to `--opentelemetry.max-shards` (#245)
 - Rename `--prometheus.min-shards` to `--opentelemetry.min-shards` (#245)
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,6 @@ Flags:
       --prometheus.max-point-age=PROMETHEUS.MAX-POINT-AGE
                                  Skip points older than this, to assist
                                  recovery. Default: 25h0m0s
-      --prometheus.max-shards=PROMETHEUS.MAX-SHARDS
-                                 Max number of shards, i.e. amount of
-                                 concurrency. Default: 200
       --prometheus.scrape-interval=PROMETHEUS.SCRAPE-INTERVAL ...
                                  Ignored. This is inferred from the Prometheus
                                  via api/v1/status/config
@@ -266,8 +263,14 @@ Flags:
                                  in PEM format (e.g., root.crt). May be
                                  repeated.
       --opentelemetry.max-bytes-per-request=OPENTELEMETRY.MAX-BYTES-PER-REQUEST
-                                 Send at most this number of bytes per
-                                 request. Default: 65536
+                                 Send at most this many bytes per request.
+                                 Default: 65536
+      --opentelemetry.min-shards=OPENTELEMETRY.MIN-SHARDS
+                                 Min number of shards, i.e. amount of
+                                 concurrency. Default: 1
+      --opentelemetry.max-shards=OPENTELEMETRY.MAX-SHARDS
+                                 Max number of shards, i.e. amount of
+                                 concurrency. Default: 200
       --opentelemetry.metrics-prefix=OPENTELEMETRY.METRICS-PREFIX
                                  Customized prefix for exporter metrics. If not
                                  set, none will be used
@@ -277,7 +280,7 @@ Flags:
                                  pass any of the filter sets to be forwarded.
       --startup.timeout=STARTUP.TIMEOUT
                                  Timeout at startup to allow the endpoint to
-                                 become available. Default: 5m0s
+                                 become available. Default: 10m0s
       --healthcheck.period=HEALTHCHECK.PERIOD
                                  Period for internal health checking; set at a
                                  minimum to the shortest Promethues scrape
@@ -297,6 +300,7 @@ Flags:
       --disable-diagnostics      Disable diagnostics by default; if unset,
                                  diagnostics will be auto-configured to the
                                  primary destination
+
 ```
 
 Two kinds of sidecar customization are available only through the
@@ -327,7 +331,7 @@ The sidecar reports validation errors using conventions established by
 Lightstep for conveying information about _partial success_ when
 writing to the OTLP destination.  These errors are returned using gRPC
 "trailers" (a.k.a. http2 response headers) and are output as metrics
-and logs.  See the `sidecar.metrics.failing` metric to diagnose validation 
+and logs.  See the `sidecar.metrics.failing` metric to diagnose validation
 errors.
 
 #### Metadata errors
@@ -530,4 +534,4 @@ past WAL segment not found, sidecar may have dragged behind. Consider increasing
 This message means that the sidecar is looking for a WAL segment file that has been removed, usually due to Prometheus triggering a checkpoint. It's possible to look at the delta between `sidecar.wal.size` (total wal entries) and `sidecar.wal.offset` (where the sidecar currently is) to determine if the sidecar has enough resources to keep up. If the offset is increasingly further behind the size, it's recommended to increase the timeseries emitted per request using the following configuration options:
 
 - `--opentelemetry.max-bytes-per-request` configures the maximum number of timeseries sent with each request from the sidecar to the OTLP backend.
-- `--prometheus.max-shards` configures the number of parallel go routines and grpc connections used to transmit the data.
+- `--opentelemetry.max-shards` configures the number of parallel go routines and grpc connections used to transmit the data.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -172,11 +172,11 @@ startup_timeout: 1777s
 					MaxPointAge: DurationConfig{
 						25 * time.Hour,
 					},
-					MinShards: 1,
-					MaxShards: 200,
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 65536,
+					MinShards:          1,
+					MaxShards:          200,
 				},
 				Admin: AdminConfig{
 					ListenIP:                  config.DefaultAdminListenIP,
@@ -268,8 +268,8 @@ log:
 				"--prometheus.wal", "wal-eeee",
 				"--prometheus.max-point-age", "10h",
 				"--opentelemetry.max-bytes-per-request", "5",
-				"--prometheus.min-shards", "5",
-				"--prometheus.max-shards", "10",
+				"--opentelemetry.min-shards", "5",
+				"--opentelemetry.max-shards", "10",
 				"--log.level=warning",
 				"--healthcheck.period=17s",
 				"--healthcheck.threshold-ratio=0.2",
@@ -285,11 +285,11 @@ log:
 					MaxPointAge: DurationConfig{
 						10 * time.Hour,
 					},
-					MinShards: 5,
-					MaxShards: 10,
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 5,
+					MinShards:          5,
+					MaxShards:          10,
 				},
 				Admin: AdminConfig{
 					ListenIP:                  config.DefaultAdminListenIP,
@@ -364,8 +364,6 @@ prometheus:
   wal: /volume/wal
   endpoint: http://127.0.0.1:19090/
   max_point_age: 72h
-  min_shards: 10
-  max_shards: 20
   scrape_intervals: [30s]
 
 startup_timeout: 33s
@@ -387,6 +385,8 @@ security:
 
 opentelemetry:
   max_bytes_per_request: 10
+  min_shards: 10
+  max_shards: 20
   metrics_prefix: prefix.
 
 filters:
@@ -429,12 +429,12 @@ static_metadata:
 					MaxPointAge: DurationConfig{
 						72 * time.Hour,
 					},
-					MinShards: 10,
-					MaxShards: 20,
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 10,
 					MetricsPrefix:      "prefix.",
+					MinShards:          10,
+					MaxShards:          20,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "https://ingest.staging.lightstep.com:443",
@@ -587,8 +587,8 @@ static_metadata:
 		{
 			"min-shards greater than max-shards", ``,
 			[]string{
-				"--prometheus.min-shards=101",
-				"--prometheus.max-shards=100",
+				"--opentelemetry.min-shards=101",
+				"--opentelemetry.max-shards=100",
 			},
 			config.MainConfig{},
 			"min-shards cannot be greater than max-shards",

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -40,13 +40,13 @@ func Example() {
 	//   "prometheus": {
 	//     "endpoint": "http://127.0.0.1:19090",
 	//     "wal": "/volume/wal",
-	//     "max_point_age": "72h0m0s",
-	//     "min_shards": 100,
-	//     "max_shards": 200
+	//     "max_point_age": "72h0m0s"
 	//   },
 	//   "opentelemetry": {
 	//     "max_bytes_per_request": 1500,
-	//     "metrics_prefix": "prefix."
+	//     "metrics_prefix": "prefix.",
+	//     "min_shards": 100,
+	//     "max_shards": 200
 	//   },
 	//   "admin": {
 	//     "listen_ip": "0.0.0.0",

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -37,7 +37,7 @@ prometheus:
 
 # OpenTelemetry settings:
 opentelemetry:
-  # Send at most this number of timeseries per request
+  # Send at most this number of bytes per request
   max_bytes_per_request: 1500
 
   # Min number of shards, i.e. amount of concurrency

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -35,16 +35,16 @@ prometheus:
   # Skip points older than this
   max_point_age: 72h
 
+# OpenTelemetry settings:
+opentelemetry:
+  # Send at most this number of timeseries per request
+  max_bytes_per_request: 1500
+
   # Min number of shards, i.e. amount of concurrency
   min_shards: 100
 
   # Max number of shards, i.e. amount of concurrency
   max_shards: 200
-
-# OpenTelemetry settings:
-opentelemetry:
-  # Send at most this number of timeseries per request
-  max_bytes_per_request: 1500
 
   # Metrics prefix is prepended to all exported metric names:
   metrics_prefix: prefix.


### PR DESCRIPTION
Same for `min-shards`. These settings apply to the output, so less about Prometheus than about OpenTelemetry. This follows the same change for `max-bytes-per-request` in the upcoming release.

Reformats the whole command-line summary section of the README.

Part of #197.
