### PR TITLE
Use a single queue, not one per shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Assemble multiple points per Metric, limit requests by size instead of points. (#237)
 - Replace `--prometheus.max-timeseries-per-request` with `--opentelemetry.max-bytes-per-request`, default 64kB (yaml: `prometheus:\nmax_timeseries_per_request:` with `opentelemetry:\nmax_bytes_per_request:`)  (#237)
 - Fix issue w/ nextSegment being set incorrectly. (#242)
+- Adds new `--opentelemetry.queue-size` setting. (#246)
 
 ## [0.23.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.0) - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Assemble multiple points per Metric, limit requests by size instead of points. (#237)
 - Replace `--prometheus.max-timeseries-per-request` with `--opentelemetry.max-bytes-per-request`, default 64kB (yaml: `prometheus:\nmax_timeseries_per_request:` with `opentelemetry:\nmax_bytes_per_request:`)  (#237)
 - Fix issue w/ nextSegment being set incorrectly. (#242)
-- Adds new `--opentelemetry.queue-size` setting. (#246)
+- Adds new `--opentelemetry.queue-size` setting. (#247)
 
 ## [0.23.0](https://github.com/lightstep/opentelemetry-prometheus-sidecar/releases/tag/v0.23.0) - 2021-04-23
 

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -265,6 +265,14 @@ func TestSuperStackDump(t *testing.T) {
 	var bout, berr bytes.Buffer
 	cmd.Stdout = &bout
 	cmd.Stderr = &berr
+
+	defer func() {
+		if t.Failed() {
+			t.Logf("stdout: %v\n", bout.String())
+			t.Logf("stderr: %v\n", berr.String())
+		}
+	}()
+
 	err := cmd.Start()
 	if err != nil {
 		t.Errorf("execution error: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,9 @@ const (
 	// How many bytes per request
 	DefaultMaxBytesPerRequest = 65536
 
+	// How many items can be queued before the reader blocks
+	DefaultQueueSize = 100000
+
 	// Min number of shards, i.e. amount of concurrency
 	DefaultMinShards = 1
 	// Max number of shards, i.e. amount of concurrency
@@ -182,16 +185,17 @@ type LogConfig struct {
 }
 
 type PromConfig struct {
-	Endpoint           string         `json:"endpoint"`
-	WAL                string         `json:"wal"`
-	MaxPointAge        DurationConfig `json:"max_point_age"`
-	MinShards          int            `json:"min_shards"`
-	MaxShards          int            `json:"max_shards"`
+	Endpoint    string         `json:"endpoint"`
+	WAL         string         `json:"wal"`
+	MaxPointAge DurationConfig `json:"max_point_age"`
+	MinShards   int            `json:"min_shards"`
+	MaxShards   int            `json:"max_shards"`
 }
 
 type OTelConfig struct {
-	MaxBytesPerRequest int            `json:"max_bytes_per_request"`
-	MetricsPrefix string `json:"metrics_prefix"`
+	MaxBytesPerRequest int    `json:"max_bytes_per_request"`
+	MetricsPrefix      string `json:"metrics_prefix"`
+	QueueSize          int    `json:"queue_size"`
 }
 
 type AdminConfig struct {
@@ -235,12 +239,8 @@ func (c MainConfig) QueueConfig() promconfig.QueueConfig {
 	cfg.MinShards = c.Prometheus.MinShards
 	cfg.MaxShards = c.Prometheus.MaxShards
 
-	// We want the queues to have enough buffer to ensure consistent flow with full batches
-	// being available for every new request.
-	// Testing with different latencies and shard numbers have shown that 3x of the batch size
-	// works well.
-	// TODO: Use a single queue (in a future PR).
-	cfg.Capacity = 1500
+	// Note: This is size of a single queue owned by the queue manager.
+	cfg.Capacity = c.OpenTelemetry.QueueSize
 
 	return cfg
 }
@@ -250,14 +250,15 @@ type FileReadFunc func(filename string) ([]byte, error)
 func DefaultMainConfig() MainConfig {
 	return MainConfig{
 		Prometheus: PromConfig{
-			WAL:                DefaultWALDirectory,
-			Endpoint:           DefaultPrometheusEndpoint,
-			MaxPointAge:        DurationConfig{DefaultMaxPointAge},
-			MinShards:          DefaultMinShards,
-			MaxShards:          DefaultMaxShards,
+			WAL:         DefaultWALDirectory,
+			Endpoint:    DefaultPrometheusEndpoint,
+			MaxPointAge: DurationConfig{DefaultMaxPointAge},
+			MinShards:   DefaultMinShards,
+			MaxShards:   DefaultMaxShards,
 		},
 		OpenTelemetry: OTelConfig{
 			MaxBytesPerRequest: DefaultMaxBytesPerRequest,
+			QueueSize:          DefaultQueueSize,
 		},
 		Admin: AdminConfig{
 			Port:                      DefaultAdminPort,
@@ -358,6 +359,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag("opentelemetry.metrics-prefix", "Customized prefix for exporter metrics. If not set, none will be used").
 		StringVar(&cfg.OpenTelemetry.MetricsPrefix)
+
+	a.Flag("opentelemetry.queue-size", fmt.Sprintf("Number of points that can accumulate before blocking the reader. Default: %d", DefaultQueueSize)).
+		IntVar(&cfg.OpenTelemetry.QueueSize)
 
 	a.Flag("filter", "PromQL metric and attribute matcher which must pass for a series to be forwarded to OpenTelemetry. If repeated, the series must pass any of the filter sets to be forwarded.").
 		StringsVar(&cfg.Filters)

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,10 @@ const (
 	DefaultMaxBytesPerRequest = 65536
 
 	// How many items can be queued before the reader blocks
+	//
+	// Note: queue entries are 16 bytes, this is a large block of memory.
+	// TODO: Consider adjusting this down after understanding performance
+	// of the single-queue approach to sharding taken in #247.
 	DefaultQueueSize = 100000
 
 	// Min number of shards, i.e. amount of concurrency

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -160,7 +160,6 @@ destination:
 
 prometheus:
   wal: wal-eeee
-  scrape_intervals: [22m13s]
 
 startup_timeout: 1777s
 `,
@@ -177,6 +176,7 @@ startup_timeout: 1777s
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 65536,
+					QueueSize:          config.DefaultQueueSize,
 				},
 				Admin: AdminConfig{
 					ListenIP:                  config.DefaultAdminListenIP,
@@ -241,7 +241,7 @@ startup_timeout: 1777s
 		{
 			// Note that attributes and headers are merged, while
 			// for other fields flags overwrite file-config.
-			"file_and_flag", `
+			"file and flag", `
 destination:
   endpoint: http://womp.womp
   attributes:
@@ -268,6 +268,7 @@ log:
 				"--prometheus.wal", "wal-eeee",
 				"--prometheus.max-point-age", "10h",
 				"--opentelemetry.max-bytes-per-request", "5",
+				"--opentelemetry.queue-size", "107",
 				"--prometheus.min-shards", "5",
 				"--prometheus.max-shards", "10",
 				"--log.level=warning",
@@ -290,6 +291,7 @@ log:
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 5,
+					QueueSize:          107,
 				},
 				Admin: AdminConfig{
 					ListenIP:                  config.DefaultAdminListenIP,
@@ -339,7 +341,7 @@ log:
 			"",
 		},
 		{
-			"all_settings", `
+			"all settings", `
 # Comments work!
 destination:
   endpoint: https://ingest.staging.lightstep.com:443
@@ -366,7 +368,6 @@ prometheus:
   max_point_age: 72h
   min_shards: 10
   max_shards: 20
-  scrape_intervals: [30s]
 
 startup_timeout: 33s
 
@@ -388,6 +389,7 @@ security:
 opentelemetry:
   max_bytes_per_request: 10
   metrics_prefix: prefix.
+  queue_size: 701
 
 filters:
 - metric{label=value}
@@ -435,6 +437,7 @@ static_metadata:
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 10,
 					MetricsPrefix:      "prefix.",
+					QueueSize:          701,
 				},
 				Destination: OTLPConfig{
 					Endpoint: "https://ingest.staging.lightstep.com:443",

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -46,7 +46,8 @@ func Example() {
 	//   },
 	//   "opentelemetry": {
 	//     "max_bytes_per_request": 1500,
-	//     "metrics_prefix": "prefix."
+	//     "metrics_prefix": "prefix.",
+	//     "queue_size": 100001
 	//   },
 	//   "admin": {
 	//     "listen_ip": "0.0.0.0",

--- a/config/sidecar.example.yaml
+++ b/config/sidecar.example.yaml
@@ -43,11 +43,15 @@ prometheus:
 
 # OpenTelemetry settings:
 opentelemetry:
-  # Send at most this number of timeseries per request
+
+# Send at most this number of timeseries per request
   max_bytes_per_request: 1500
 
   # Metrics prefix is prepended to all exported metric names:
   metrics_prefix: prefix.
+
+  # Outbound queue size limit
+  queue_size: 100001
 
 # Administrative settings:
 admin:

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -391,7 +391,7 @@ func appendSamples(appender Appender, samples []*metric_pb.Metric) {
 
 			newPt := pms[0]
 			total := proto.Size(newPt)
-			cnt := 0
+			cnt := 1
 
 			pms = pms[1:]
 


### PR DESCRIPTION
Adds `--opentelemetry.queue-size`, defaults to 100k.  The former setting was 1500 per shard. This is 10x larger than we've seen in practice w/ the former arrangement, based on the `sidecar.queue.size` metric from a large user.

Changes two `int` fields to `uint32` where the sizes are guaranteed to be positive and smaller than the size of a Prometheus WAL segment. This saves 800kB of memory by default. Added TODO to consider lowering the queue size after performance is better understood.

Resolves #197.
