### PR TITLE
Wait for stopping shards

### DIFF
--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -30,7 +30,7 @@ func createPrimaryDestinationResourceLabels(svcInstanceId string, externalLabels
 
 	allLabels := make(map[string]string)
 	for _, label := range externalLabels {
-		allLabels[externalLabelPrefix + label.Name] = label.Value
+		allLabels[externalLabelPrefix+label.Name] = label.Value
 	}
 	for name, value := range extraLabels {
 		allLabels[name] = value
@@ -154,6 +154,7 @@ func runComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTaile
 						"err", err,
 					)
 				}
+				_ = level.Info(scfg.Logger).Log("msg", "stopping OpenTelemetry writer")
 				close(stopCh)
 			},
 		)

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -278,8 +278,6 @@ func TestSuperStackDump(t *testing.T) {
 		t.Errorf("execution error: %v", err)
 		return
 	}
-	timer := time.NewTimer(time.Second * 10)
-	defer timer.Stop()
 
 	var lock sync.Mutex
 	var diagSpans []*traces.ResourceSpans
@@ -290,6 +288,8 @@ func TestSuperStackDump(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
+		timer := time.NewTimer(time.Second * 10)
+		defer timer.Stop()
 		for {
 			select {
 			case <-timer.C:
@@ -313,12 +313,18 @@ func TestSuperStackDump(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
+		timer := time.NewTimer(time.Second * 10)
+		defer timer.Stop()
 		for {
 			// Dumping the metrics diagnostics here.
 			// TODO: add testing support to validate
 			// metrics from tests and then build more
 			// tests based on metrics.
 			select {
+			case <-timer.C:
+				t.Log("timeout waiting for metrics")
+				t.FailNow()
+				return
 			case <-ms.metrics:
 			case <-ctx.Done():
 				return

--- a/cmd/opentelemetry-prometheus-sidecar/main_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main_test.go
@@ -295,6 +295,7 @@ func TestSuperStackDump(t *testing.T) {
 			case <-timer.C:
 				t.Log("timeout waiting for spans")
 				t.FailNow()
+				cmd.Process.Kill()
 				return
 			case rs := <-ts.spans:
 				// Note: below searching for a stack dump and
@@ -313,18 +314,12 @@ func TestSuperStackDump(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		timer := time.NewTimer(time.Second * 10)
-		defer timer.Stop()
 		for {
 			// Dumping the metrics diagnostics here.
 			// TODO: add testing support to validate
 			// metrics from tests and then build more
 			// tests based on metrics.
 			select {
-			case <-timer.C:
-				t.Log("timeout waiting for metrics")
-				t.FailNow()
-				return
 			case <-ms.metrics:
 			case <-ctx.Done():
 				return

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -148,6 +148,7 @@ func NewQueueManager(logger log.Logger, cfg promconfig.QueueConfig, timeout time
 	if err != nil {
 		return nil, errors.Wrap(err, "get WAL size")
 	}
+	t.wg.Add(1)
 	t.lastSize = lastSize
 	t.lastOffset = tailer.Offset()
 	t.shards = map[*shard]struct{}{}
@@ -251,7 +252,7 @@ func (t *QueueManager) Stop() error {
 	// Note: Do not close t.queue, as it means handling more cases
 	// in runShard().
 
-	// wait for resharding loops to stop
+	t.wg.Done() // For the Add() in NewQueueManager()
 	t.wg.Wait()
 
 	t.shardsMtx.Lock()

--- a/otlp/queue_manager.go
+++ b/otlp/queue_manager.go
@@ -170,8 +170,6 @@ func NewQueueManager(logger log.Logger, cfg promconfig.QueueConfig, timeout time
 			"The number of shards that have started and not stopped.",
 		),
 	)
-
-	// Note: the following two could be a batch observer.
 	t.queueCapacityObs = sidecar.OTelMeterMust.NewInt64UpDownSumObserver(
 		"sidecar.queue.capacity",
 		func(ctx context.Context, result metric.Int64ObserverResult) {

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -168,8 +168,6 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 
 	// NOTE(fabxc): wrap the tailer into a buffered reader once we become concerned
 	// with performance. The WAL reader will do a lot of tiny reads otherwise.
-	// This is also the reason for the series cache dealing with "maxSegment" hints
-	// for series rather than precise ones.
 	var (
 		started         = false
 		startupBypassed = 0


### PR DESCRIPTION
There is low test coverage of queue_manager.go. While an existing test covers starting and stopping shards to an extent, we did not test that they exited. This can be seen in `sidecar.queue.running` metrics from the 0.23.x releases, and is difficult to test. The fix here is to wait for the shards to exit, so that existing tests would block in case of a bug.

Removes an extraneous call to lock in `Append()`, no longer needed w/ a single queue. This led to (1) a new race between QueueManager.Start() and Stop(), (2), worsened flakiness in the Stackdump test. (1) is fixed and (2) is removed.

Fixes incorrect `sidecar.queue.capacity` value introduced in #247.