### PR TITLE
Properly copy the main destination config to diagnostics.

### DIFF
--- a/cmd/internal/start_telemetry.go
+++ b/cmd/internal/start_telemetry.go
@@ -22,7 +22,8 @@ func StartTelemetry(scfg SidecarConfig, defaultSvcName string, isSuper bool) *te
 	}
 
 	if diagConfig.Endpoint == "" {
-		diagConfig = scfg.Destination
+		// Create a copy, as we adjust the headers/attributes.
+		diagConfig = scfg.Destination.Copy()
 	}
 
 	if diagConfig.Endpoint == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -178,13 +178,13 @@ type OTLPConfig struct {
 func (config OTLPConfig) Copy() OTLPConfig {
 	rv := config
 
-	headers := make(map[string]string)
+	headers := map[string]string{}
 	for key, value := range config.Headers {
 		headers[key] = value
 	}
 	rv.Headers = headers
 
-	attrs := make(map[string]string)
+	attrs := map[string]string{}
 	for key, value := range config.Attributes {
 		attrs[key] = value
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -175,6 +175,24 @@ type OTLPConfig struct {
 	Compression string            `json:"compression"`
 }
 
+func (config OTLPConfig) Copy() OTLPConfig {
+	rv := config
+
+	headers := make(map[string]string)
+	for key, value := range config.Headers {
+		headers[key] = value
+	}
+	rv.Headers = headers
+
+	attrs := make(map[string]string)
+	for key, value := range config.Attributes {
+		attrs[key] = value
+	}
+	rv.Attributes = attrs
+
+	return rv
+}
+
 type LogConfig struct {
 	Level   string `json:"level"`
 	Format  string `json:"format"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -622,15 +622,10 @@ static_metadata:
 }
 
 func TestCopyOTLPConfig(t *testing.T) {
-	headers := make(map[string]string)
-	headers["header"] = "value"
-	attrs := make(map[string]string)
-	attrs["attr"] = "value"
-
 	cfg := OTLPConfig{
 		Endpoint:    "http://otlp",
-		Headers:     headers,
-		Attributes:  attrs,
+		Headers:     map[string]string{"a": "b"},
+		Attributes:  map[string]string{"c": "d"},
 		Timeout:     DurationConfig{time.Since(time.Now())},
 		Compression: "gzip",
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -620,3 +620,27 @@ static_metadata:
 		})
 	}
 }
+
+func TestCopyOTLPConfig(t *testing.T) {
+	headers := make(map[string]string)
+	headers["header"] = "value"
+	attrs := make(map[string]string)
+	attrs["attr"] = "value"
+
+	cfg := OTLPConfig{
+		Endpoint:    "http://otlp",
+		Headers:     headers,
+		Attributes:  attrs,
+		Timeout:     DurationConfig{time.Since(time.Now())},
+		Compression: "gzip",
+	}
+	copied_cfg := cfg.Copy()
+	require.Equal(t, cfg, copied_cfg)
+
+	copied_cfg.Headers["foo"] = "bar"
+	copied_cfg.Attributes["bar"] = "foo"
+	require.Equal(t, len(cfg.Headers), 1)
+	require.Equal(t, len(cfg.Attributes), 1)
+	require.Equal(t, len(copied_cfg.Headers), 2)
+	require.Equal(t, len(copied_cfg.Attributes), 2)
+}


### PR DESCRIPTION
We are using the main configuration as fallback in case no diagnostics configuration is provided, hence we need to *copy* the entire struct as we mutate it later.

@jmacd we are already logging the **main** configuration prior to start it all (by calling `logStartup()`). Think we should be logging the supervisor config? (sounds like a NO).