### PR TITLE
add counter for tombstone records

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ sidecar performance.
 | sidecar.segment.reads | counter | number of WAL segment read() calls | |
 | sidecar.segment.bytes | counter | number of WAL segment bytes read | |
 | sidecar.segment.skipped | counter | number of skipped WAL segments | |
+| sidecar.tombstones.dropped | counter | number of tombstone records dropped | |
 
 ## Upstream
 

--- a/config/config.go
+++ b/config/config.go
@@ -111,15 +111,16 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 
 	// Some metric names are shared across packages, for healthchecking.
 
-	SidecarPrefix        = "sidecar."
-	SeriesDefinedMetric  = "sidecar.series.defined"
-	OutcomeMetric        = "sidecar.queue.outcome"
-	DroppedSeriesMetric  = "sidecar.series.dropped"
-	ProducedPointsMetric = "sidecar.points.produced"
-	DroppedPointsMetric  = "sidecar.points.dropped"
-	SkippedPointsMetric  = "sidecar.points.skipped"
-	FailingMetricsMetric = "sidecar.metrics.failing"
-	CurrentSeriesMetric  = "sidecar.series.current"
+	SidecarPrefix           = "sidecar."
+	SeriesDefinedMetric     = "sidecar.series.defined"
+	OutcomeMetric           = "sidecar.queue.outcome"
+	DroppedSeriesMetric     = "sidecar.series.dropped"
+	ProducedPointsMetric    = "sidecar.points.produced"
+	DroppedPointsMetric     = "sidecar.points.dropped"
+	SkippedPointsMetric     = "sidecar.points.skipped"
+	FailingMetricsMetric    = "sidecar.metrics.failing"
+	CurrentSeriesMetric     = "sidecar.series.current"
+	TombstonesDroppedMetric = "sidecar.tombstones.dropped"
 
 	OutcomeKey          = attribute.Key("outcome")
 	OutcomeSuccessValue = "success"


### PR DESCRIPTION
Still needs tests, but adding a counter to track any tombstone records that the sidecar currently drops.