### PR TITLE
add current metrics count by metric type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,15 +111,20 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 
 	// Some metric names are shared across packages, for healthchecking.
 
-	SidecarPrefix        = "sidecar."
-	SeriesDefinedMetric  = "sidecar.series.defined"
-	OutcomeMetric        = "sidecar.queue.outcome"
-	DroppedSeriesMetric  = "sidecar.series.dropped"
+	SidecarPrefix = "sidecar."
+
+	SeriesDefinedMetric = "sidecar.series.defined"
+	DroppedSeriesMetric = "sidecar.series.dropped"
+	CurrentSeriesMetric = "sidecar.series.current"
+
+	OutcomeMetric = "sidecar.queue.outcome"
+
 	ProducedPointsMetric = "sidecar.points.produced"
 	DroppedPointsMetric  = "sidecar.points.dropped"
 	SkippedPointsMetric  = "sidecar.points.skipped"
+
 	FailingMetricsMetric = "sidecar.metrics.failing"
-	CurrentSeriesMetric  = "sidecar.series.current"
+	CurrentMetricsMetric = "sidecar.metrics.current"
 
 	OutcomeKey          = attribute.Key("outcome")
 	OutcomeSuccessValue = "success"
@@ -673,4 +678,3 @@ type MetadataEntry struct {
 	ValueType  ValueType
 	Help       string
 }
-

--- a/go.sum
+++ b/go.sum
@@ -763,7 +763,6 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -106,7 +106,7 @@ func NewCache(client *http.Client, targetMetadataURL *url.URL, metadataURL *url.
 			for metricType, c := range counters {
 				result.Observe(c, t.String(string(metricType)))
 			}
-			result.Observe(notFound, attribute.String("status", "notFound"))
+			result.Observe(notFound, t.String("metadata_not_found"))
 		},
 		metric.WithDescription(
 			"The current number of metrics in the metadata cache.",


### PR DESCRIPTION
This adds counters for the current number of metrics in `metadata.Cache`. It also measure metrics that metadata was not found.


[link to dash](https://app.staging.lightstep.com/dev-gustavo/dashboard/sidecar-dev/H4SrVjtj?chart_id=4Rxhg3F3)
![image](https://user-images.githubusercontent.com/7898464/119865611-3b3abb80-bef2-11eb-956e-37740c9212cf.png)
