### PR TITLE
stop sending metrics from non leader sidecars

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -24,7 +24,7 @@ type SidecarConfig struct {
 
 	FailingReporter common.FailingReporter
 
-	LeaderElector leader.Candidate
+	LeaderCandidate leader.Candidate
 
 	config.MainConfig
 }

--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -119,7 +119,7 @@ func runComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTaile
 		scfg.Prometheus.MaxPointAge.Duration,
 		scfg.Monitor.GetScrapeConfig(),
 		scfg.FailingReporter,
-		scfg.LeaderElector,
+		scfg.LeaderCandidate,
 	)
 
 	var g run.Group

--- a/cmd/internal/start_components.go
+++ b/cmd/internal/start_components.go
@@ -119,6 +119,7 @@ func runComponents(ctx context.Context, scfg SidecarConfig, tailer tail.WalTaile
 		scfg.Prometheus.MaxPointAge.Duration,
 		scfg.Monitor.GetScrapeConfig(),
 		scfg.FailingReporter,
+		scfg.LeaderElector,
 	)
 
 	var g run.Group

--- a/cmd/internal/start_leader.go
+++ b/cmd/internal/start_leader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -42,7 +43,10 @@ func StartLeaderElection(ctx context.Context, cfg *SidecarConfig) error {
 	}
 	lockID := cleanName(externalLabels.Get(IDKey))
 	if lockID == "" {
-		lockID = fmt.Sprintf("unlabeled-%016x", rand.Uint64())
+		src := rand.NewSource(time.Now().UnixNano())
+		r := rand.New(src)
+
+		lockID = fmt.Sprintf("unlabeled-%016x", r.Uint64())
 	}
 
 	logger := log.With(cfg.Logger, "component", "leader")

--- a/cmd/internal/start_leader.go
+++ b/cmd/internal/start_leader.go
@@ -56,7 +56,7 @@ func StartLeaderElection(ctx context.Context, cfg *SidecarConfig) error {
 		return errors.Wrap(err, "leader election client")
 	}
 
-	cfg.LeaderElector, err = leader.NewCandidate(
+	cfg.LeaderCandidate, err = leader.NewKubernetesCandidate(
 		client,
 		lockNamespace,
 		lockName,
@@ -75,7 +75,7 @@ func StartLeaderElection(ctx context.Context, cfg *SidecarConfig) error {
 		"ID", lockID,
 	)
 
-	if err := cfg.LeaderElector.Start(ctx); err != nil {
+	if err := cfg.LeaderCandidate.Start(ctx); err != nil {
 		return errors.Wrap(err, "leader election start")
 	}
 	return nil

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/lightstep/opentelemetry-prometheus-sidecar/leader"
 	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
@@ -117,6 +118,7 @@ func Main() bool {
 		MetadataCache:   nil,
 		MainConfig:      cfg,
 		FailingReporter: common.NewFailingSet(log.With(logger, "component", "failing_metrics")),
+		LeaderCandidate: leader.NewAlwaysLeaderCandidate(),
 	}
 
 	telemetry.StaticSetup(scfg.Logger)
@@ -201,7 +203,7 @@ func Main() bool {
 	// metrics controller will be ready for consumption upon starting telemetry.
 	metricsContGetter := ControllerGetter{}
 	healthChecker := health.NewChecker(
-		&metricsContGetter, scfg.Monitor, scfg.Admin.HealthCheckPeriod.Duration, scfg.Logger, scfg.Admin.HealthCheckThresholdRatio, scfg.LeaderElector,
+		&metricsContGetter, scfg.Monitor, scfg.Admin.HealthCheckPeriod.Duration, scfg.Logger, scfg.Admin.HealthCheckThresholdRatio, scfg.LeaderCandidate,
 	)
 
 	// Start the admin server.

--- a/cmd/opentelemetry-prometheus-sidecar/validation_test.go
+++ b/cmd/opentelemetry-prometheus-sidecar/validation_test.go
@@ -200,7 +200,7 @@ outer:
 				var reason, mname string
 				for _, label := range labels {
 					switch attribute.Key(label.Key) {
-					case common.DroppedKeyReason:
+					case common.ReasonKey:
 						reason = label.Value
 					case common.MetricNameKey:
 						mname = label.Value

--- a/common/failingset.go
+++ b/common/failingset.go
@@ -128,7 +128,7 @@ func (i *FailingSet) observeLocked(result metric.Int64ObserverResult) stateMap {
 			}
 			observedCount++
 			result.Observe(failingConstant,
-				DroppedKeyReason.String(reason),
+				ReasonKey.String(reason),
 				MetricNameKey.String(metricName),
 			)
 		}

--- a/common/instruments.go
+++ b/common/instruments.go
@@ -25,6 +25,6 @@ var (
 )
 
 const (
-	DroppedKeyReason attribute.Key = "key_reason"
-	MetricNameKey    attribute.Key = "metric_name"
+	ReasonKey     attribute.Key = "key_reason"
+	MetricNameKey attribute.Key = "metric_name"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,8 @@ an OpenTelemetry (https://opentelemetry.io) Protocol endpoint.
 	FailingMetricsMetric = "sidecar.metrics.failing"
 	CurrentMetricsMetric = "sidecar.metrics.current"
 
+	LeadershipMetric = "sidecar.leadership"
+
 	OutcomeKey          = attribute.Key("outcome")
 	OutcomeSuccessValue = "success"
 

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -42,6 +42,20 @@ type LoggingController struct {
 	log.Logger
 }
 
+func NewAlwaysLeaderCandidate() Candidate {
+	return alwaysLeader{}
+}
+
+type alwaysLeader struct{}
+
+func (a alwaysLeader) Start(_ context.Context) error {
+	return nil
+}
+
+func (a alwaysLeader) IsLeader() bool {
+	return true
+}
+
 func NewClient() (*kubernetes.Clientset, error) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -54,7 +68,7 @@ func NewClient() (*kubernetes.Clientset, error) {
 	return client, err
 }
 
-func NewCandidate(client kubernetes.Interface, namespace, name, id string, ctrl Controller, logger log.Logger) (Candidate, error) {
+func NewKubernetesCandidate(client kubernetes.Interface, namespace, name, id string, ctrl Controller, logger log.Logger) (Candidate, error) {
 	c := &candidate{
 		client: client,
 		ctrl:   ctrl,
@@ -120,6 +134,8 @@ func (c *candidate) Start(ctx context.Context) error {
 
 	return nil
 }
+
+var _ Candidate = (*alwaysLeader)(nil)
 
 func (c *candidate) IsLeader() bool {
 	return c.elector.IsLeader()

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -26,7 +26,7 @@ func newTest() *testController {
 func TestLeaderElection(t *testing.T) {
 	fc := fake.NewSimpleClientset()
 	tc := newTest()
-	le, err := NewCandidate(fc, "default", "hello", "world", tc, telemetry.DefaultLogger())
+	le, err := NewKubernetesCandidate(fc, "default", "hello", "world", tc, telemetry.DefaultLogger())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -308,7 +308,7 @@ func (c *Client) parseResponseMetadata(ctx context.Context, md grpcMetadata.MD) 
 				common.DroppedPoints.Add(
 					ctx,
 					int64(points),
-					common.DroppedKeyReason.String("validation"),
+					common.ReasonKey.String("validation"),
 				)
 			}
 		} else if key == "otlp-metrics-dropped" {
@@ -316,7 +316,7 @@ func (c *Client) parseResponseMetadata(ctx context.Context, md grpcMetadata.MD) 
 				common.DroppedSeries.Add(
 					ctx,
 					int64(points),
-					common.DroppedKeyReason.String("validation"),
+					common.ReasonKey.String("validation"),
 				)
 			}
 		} else if strings.HasPrefix(key, invalidTrailerPrefix) {

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -231,7 +231,7 @@ Outer:
 				common.DroppedSeries.Add(
 					ctx,
 					int64(failed),
-					common.DroppedKeyReason.String("metadata"),
+					common.ReasonKey.String("metadata"),
 				)
 			}
 			seriesDefined.Add(ctx, int64(success))
@@ -303,7 +303,7 @@ Outer:
 			}
 
 			if !r.leaderCandidate.IsLeader() {
-				common.SkippedPoints.Add(ctx, int64(len(outputs)), attribute.String("reason", "not_leader"))
+				common.SkippedPoints.Add(ctx, int64(len(outputs)), common.ReasonKey.String("not_leader"))
 				// This side is not the leader, we should not append these samples.
 				continue
 			}
@@ -312,7 +312,7 @@ Outer:
 
 			if droppedPoints != 0 {
 				common.DroppedPoints.Add(ctx, int64(droppedPoints),
-					common.DroppedKeyReason.String("metadata"),
+					common.ReasonKey.String("metadata"),
 				)
 			}
 			if skippedPoints != 0 {

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -59,18 +59,6 @@ func (a *nopAppender) getSamples() []SizedMetric {
 	return a.samples
 }
 
-type alwaysLeader struct{}
-
-func (a alwaysLeader) Start(_ context.Context) error {
-	return nil
-}
-
-func (a alwaysLeader) IsLeader() bool {
-	return true
-}
-
-var _ leader.Candidate = (*alwaysLeader)(nil)
-
 func TestReader_Progress(t *testing.T) {
 	dir, err := ioutil.TempDir("", "progress")
 	if err != nil {
@@ -107,7 +95,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	failingSet := testFailingReporter{}
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, nil, failingSet, &alwaysLeader{})
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, &nopAppender{}, "", 0, nil, failingSet, leader.NewAlwaysLeaderCandidate())
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -173,7 +161,7 @@ func TestReader_Progress(t *testing.T) {
 
 	recorder := &nopAppender{}
 
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, nil, failingSet, &alwaysLeader{})
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, metadataMap, recorder, "", 0, nil, failingSet, leader.NewAlwaysLeaderCandidate())
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.


### PR DESCRIPTION
This stop sending points to the queue manager when the sidecar is not the leader. 

There is a health check that verifies if enough points was produced in the last few minutes that needed to be disabled for non-leaders as these don't produce anything until it becomes the leader.

This also fixes two bugs:
1. the sidecar id was being created without setting a random source, causing all replicas to have the same id;
2. the leader verification was done with the wrong id, causing all replicas to become the leader;
