### PR TITLE
create a flag to set the timeout for health-check requests to prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Flags:
       --prometheus.max-point-age=PROMETHEUS.MAX-POINT-AGE
                                  Skip points older than this, to assist
                                  recovery. Default: 25h0m0s
+      --prometheus.health-check-request-timeout=PROMETHEUS.HEALTH-CHECK-REQUEST-TIMEOUT  
+                                 Timeout used for health-check requests to the prometheus endpoint. Default: 5s
       --prometheus.scrape-interval=PROMETHEUS.SCRAPE-INTERVAL ...
                                  Ignored. This is inferred from the Prometheus
                                  via api/v1/status/config

--- a/cmd/opentelemetry-prometheus-sidecar/main.go
+++ b/cmd/opentelemetry-prometheus-sidecar/main.go
@@ -159,6 +159,7 @@ func Main() bool {
 		Logger:                         log.With(scfg.Logger, "component", "prom_ready"),
 		PromURL:                        promURL,
 		StartupDelayEffectiveStartTime: time.Now(),
+		HealthCheckRequestTimeout:      scfg.Prometheus.HealthCheckRequestTimeout.Duration,
 	})
 
 	targetsMetadataURL, err := promURL.Parse(config.PrometheusTargetMetadataEndpointPath)

--- a/config/config.go
+++ b/config/config.go
@@ -225,7 +225,7 @@ type PromConfig struct {
 	Endpoint                  string         `json:"endpoint"`
 	WAL                       string         `json:"wal"`
 	MaxPointAge               DurationConfig `json:"max_point_age"`
-	HealthCheckRequestTimeout DurationConfig `json:"health-check-request-timeout"`
+	HealthCheckRequestTimeout DurationConfig `json:"health_check_request_timeout"`
 }
 
 type OTelConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -222,9 +222,10 @@ type LogConfig struct {
 }
 
 type PromConfig struct {
-	Endpoint    string         `json:"endpoint"`
-	WAL         string         `json:"wal"`
-	MaxPointAge DurationConfig `json:"max_point_age"`
+	Endpoint                  string         `json:"endpoint"`
+	WAL                       string         `json:"wal"`
+	MaxPointAge               DurationConfig `json:"max_point_age"`
+	HealthCheckRequestTimeout DurationConfig `json:"health-check-request-timeout"`
 }
 
 type OTelConfig struct {
@@ -298,9 +299,10 @@ type FileReadFunc func(filename string) ([]byte, error)
 func DefaultMainConfig() MainConfig {
 	return MainConfig{
 		Prometheus: PromConfig{
-			WAL:         DefaultWALDirectory,
-			Endpoint:    DefaultPrometheusEndpoint,
-			MaxPointAge: DurationConfig{DefaultMaxPointAge},
+			WAL:                       DefaultWALDirectory,
+			Endpoint:                  DefaultPrometheusEndpoint,
+			MaxPointAge:               DurationConfig{DefaultMaxPointAge},
+			HealthCheckRequestTimeout: DurationConfig{DefaultHealthCheckTimeout},
 		},
 		OpenTelemetry: OTelConfig{
 			MaxBytesPerRequest: DefaultMaxBytesPerRequest,
@@ -383,6 +385,9 @@ func Configure(args []string, readFunc FileReadFunc) (MainConfig, map[string]str
 
 	a.Flag("prometheus.max-point-age", "Skip points older than this, to assist recovery. Default: "+DefaultMaxPointAge.String()).
 		DurationVar(&cfg.Prometheus.MaxPointAge.Duration)
+
+	a.Flag("prometheus.health-check-request-timeout", "Timeout used for health-check requests to prometheus. Default: "+DefaultHealthCheckTimeout.String()).
+		DurationVar(&cfg.Prometheus.HealthCheckRequestTimeout.Duration)
 
 	var ignoredScrapeIntervals []string
 	a.Flag("prometheus.scrape-interval", "Ignored. This is inferred from the Prometheus via api/v1/status/config").
@@ -639,6 +644,7 @@ type PromReady struct {
 	Logger                         log.Logger
 	PromURL                        *url.URL
 	StartupDelayEffectiveStartTime time.Time
+	HealthCheckRequestTimeout      time.Duration
 }
 
 // TODO: The use of Kind and ValueType are Stackdriver terms that

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,6 +173,8 @@ startup_timeout: 1777s
 					MaxPointAge: DurationConfig{
 						25 * time.Hour,
 					},
+					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
+					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 65536,
@@ -290,6 +292,7 @@ log:
 					MaxPointAge: DurationConfig{
 						10 * time.Hour,
 					},
+					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 5,
@@ -444,6 +447,7 @@ leader_election:
 					MaxPointAge: DurationConfig{
 						72 * time.Hour,
 					},
+					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 10,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,7 +162,7 @@ destination:
 
 prometheus:
   wal: wal-eeee
-
+  health_check_request_timeout: 5m
 startup_timeout: 1777s
 `,
 			nil,
@@ -173,7 +173,7 @@ startup_timeout: 1777s
 					MaxPointAge: DurationConfig{
 						25 * time.Hour,
 					},
-					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
+					HealthCheckRequestTimeout: DurationConfig{5 * time.Minute},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 65536,
@@ -270,6 +270,7 @@ log:
 				"--destination.compression", "compression_fmt",
 				"--prometheus.wal", "wal-eeee",
 				"--prometheus.max-point-age", "10h",
+				"--prometheus.health-check-request-timeout", "1m",
 				"--opentelemetry.max-bytes-per-request", "5",
 				"--opentelemetry.min-shards", "5",
 				"--opentelemetry.max-shards", "10",
@@ -291,7 +292,7 @@ log:
 					MaxPointAge: DurationConfig{
 						10 * time.Hour,
 					},
-					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
+					HealthCheckRequestTimeout: DurationConfig{time.Minute},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 5,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,7 +174,6 @@ startup_timeout: 1777s
 						25 * time.Hour,
 					},
 					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
-					HealthCheckRequestTimeout: DurationConfig{config.DefaultHealthCheckTimeout},
 				},
 				OpenTelemetry: OTelConfig{
 					MaxBytesPerRequest: 65536,

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -40,7 +40,8 @@ func Example() {
 	//   "prometheus": {
 	//     "endpoint": "http://127.0.0.1:19090",
 	//     "wal": "/volume/wal",
-	//     "max_point_age": "72h0m0s"
+	//     "max_point_age": "72h0m0s",
+	//     "health_check_request_timeout": "5s"
 	//   },
 	//   "opentelemetry": {
 	//     "max_bytes_per_request": 1500,

--- a/internal/promtest/fake.go
+++ b/internal/promtest/fake.go
@@ -167,8 +167,9 @@ func (fp *FakePrometheus) Test() *url.URL {
 
 func (fp *FakePrometheus) ReadyConfig() config.PromReady {
 	return config.PromReady{
-		Logger:  telemetry.DefaultLogger(),
-		PromURL: fp.Test(),
+		Logger:                    telemetry.DefaultLogger(),
+		PromURL:                   fp.Test(),
+		HealthCheckRequestTimeout: config.DefaultHealthCheckTimeout,
 	}
 }
 

--- a/prometheus/ready.go
+++ b/prometheus/ready.go
@@ -22,7 +22,7 @@ const (
 )
 
 func (m *Monitor) scrapeMetrics(inCtx context.Context) (Result, error) {
-	ctx, cancel := context.WithTimeout(inCtx, config.DefaultHealthCheckTimeout)
+	ctx, cancel := context.WithTimeout(inCtx, m.cfg.HealthCheckRequestTimeout)
 	defer cancel()
 
 	return m.GetMetrics(ctx)
@@ -117,7 +117,7 @@ func (m *Monitor) completedFirstScrapes(res Result, promcfg promconfig.Config, p
 }
 
 func (m *Monitor) getConfig(inCtx context.Context) (promconfig.Config, error) {
-	ctx, cancel := context.WithTimeout(inCtx, config.DefaultHealthCheckTimeout)
+	ctx, cancel := context.WithTimeout(inCtx, m.cfg.HealthCheckRequestTimeout)
 	defer cancel()
 
 	return m.GetConfig(ctx)
@@ -172,11 +172,11 @@ func (m *Monitor) WaitForReady(inCtx context.Context, inCtxCancel context.Cancel
 	// will try again and this lets us avoid the first sleep
 	warnSkipped := false
 
-	tick := time.NewTicker(config.DefaultHealthCheckTimeout)
+	tick := time.NewTicker(m.cfg.HealthCheckRequestTimeout)
 	defer tick.Stop()
 
 	for {
-		ctx, cancel := context.WithTimeout(inCtx, config.DefaultHealthCheckTimeout)
+		ctx, cancel := context.WithTimeout(inCtx, m.cfg.HealthCheckRequestTimeout)
 		req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 		if err != nil {
 			cancel()

--- a/prometheus/ready_test.go
+++ b/prometheus/ready_test.go
@@ -76,8 +76,9 @@ func TestReadyFail(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*config.DefaultHealthCheckTimeout)
 	defer cancel()
 	err = NewMonitor(config.PromReady{
-		Logger:  logger,
-		PromURL: tu,
+		Logger:                    logger,
+		PromURL:                   tu,
+		HealthCheckRequestTimeout: config.DefaultHealthCheckTimeout,
 	}).WaitForReady(ctx, cancel)
 	require.Error(t, err)
 }


### PR DESCRIPTION
This is handy for setups where the prometheus server can get overloaded, timing out critical requests of the sidecar and making it restart.

@lightstep/team-data-onboarding 